### PR TITLE
ASNIDE-7 - AsnEditor added

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -33,6 +33,10 @@
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
 
+#include <utils/mimetypes/mimedatabase.h>
+
+#include "asneditor.h"
+
 namespace Asn1Acn {
 namespace Internal {
 
@@ -58,6 +62,10 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
 
     Q_UNUSED(arguments)
     Q_UNUSED(errorString)
+
+    Utils::MimeDatabase::addMimeTypes(":/asn1acn/asn1acn.mimetypes.xml");
+
+    addAutoReleasedObject(new AsnEditorFactory);
 
     return true;
 }

--- a/asn1acn.mimetypes.xml
+++ b/asn1acn.mimetypes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+    <mime-type type="text/x-asn1">
+        <sub-class-of type="text/plain"/>
+        <comment>ASN.1 Data Model</comment>
+        <glob pattern="*.asn"/>
+        <glob pattern="*.asn1"/>
+    </mime-type>
+</mime-info>

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -28,12 +28,16 @@ DEFINES += ASN1ACN_LIBRARY
 # asn1acn plugin files
 
 SOURCES += \
-    asn1acn.cpp
+    asn1acn.cpp \
+    asneditor.cpp \
+    asndocument.cpp
 
 HEADERS += \
     asn1acn_global.h \
     asn1acnconstants.h \
-    asn1acn.h
+    asn1acn.h \
+    asneditor.h \
+    asndocument.h
 
 DISTFILES += \
     LICENSE \
@@ -57,9 +61,10 @@ isEmpty(IDE_BUILD_TREE): IDE_BUILD_TREE = "/opt/qt-creator-dev/build-debug"
 
 QTC_PLUGIN_NAME = Asn1Acn
 QTC_LIB_DEPENDS += \
-    # nothing here at this time
+    utils
 
 QTC_PLUGIN_DEPENDS += \
+    texteditor \
     coreplugin
 
 QTC_PLUGIN_RECOMMENDS += \
@@ -68,3 +73,6 @@ QTC_PLUGIN_RECOMMENDS += \
 ###### End _dependencies.pri contents ######
 
 include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
+
+RESOURCES += \
+    asn1acn.qrc

--- a/asn1acn.qrc
+++ b/asn1acn.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/asn1acn">
+        <file>asn1acn.mimetypes.xml</file>
+    </qresource>
+</RCC>

--- a/asndocument.cpp
+++ b/asndocument.cpp
@@ -23,17 +23,30 @@
 **
 ****************************************************************************/
 
-#pragma once
+#include "asndocument.h"
 
-namespace Asn1Acn {
-namespace Constants {
+#include "asn1acnconstants.h"
 
-const char LANG_ASN1[] = "ASN.1";
+using namespace Asn1Acn::Internal;
 
-const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
-const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
+AsnDocument::AsnDocument()
+{
+    setId(Constants::ASNEDITOR_ID);
 
-const char ASN1_MIMETYPE[] = "text/x-asn1";
+    /*
+     * setSyntaxHighlighter(new CppHighlighter);
+    setIndenter(new CppTools::CppQtStyleIndenter);
 
-} // namespace Asn1Acn
-} // namespace Constants
+    connect(this, &TextEditor::TextDocument::tabSettingsChanged,
+            this, &CppEditorDocument::invalidateFormatterCache);
+    connect(this, &Core::IDocument::mimeTypeChanged,
+            this, &CppEditorDocument::onMimeTypeChanged);
+
+    connect(this, &Core::IDocument::aboutToReload,
+            this, &CppEditorDocument::onAboutToReload);
+    connect(this, &Core::IDocument::reloadFinished,
+            this, &CppEditorDocument::onReloadFinished);
+    connect(this, &IDocument::filePathChanged,
+            this, &CppEditorDocument::onFilePathChanged);
+     * **/
+}

--- a/asndocument.h
+++ b/asndocument.h
@@ -23,17 +23,20 @@
 **
 ****************************************************************************/
 
+#include <texteditor/textdocument.h>
+
 #pragma once
 
 namespace Asn1Acn {
-namespace Constants {
+namespace Internal {
 
-const char LANG_ASN1[] = "ASN.1";
+class AsnDocument : public TextEditor::TextDocument
+{
+    Q_OBJECT
 
-const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
-const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
+public:
+    explicit AsnDocument();
+};
 
-const char ASN1_MIMETYPE[] = "text/x-asn1";
-
+} // namespace Internal
 } // namespace Asn1Acn
-} // namespace Constants

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asneditor.h"
+
+#include <QApplication>
+
+#include <texteditor/texteditoractionhandler.h>
+
+#include "asn1acnconstants.h"
+#include "asndocument.h"
+
+using namespace Asn1Acn::Internal;
+
+AsnEditor::AsnEditor()
+{
+    addContext(Constants::LANG_ASN1);
+}
+
+AsnEditorFactory::AsnEditorFactory()
+{
+    setId(Constants::ASNEDITOR_ID);
+    setDisplayName(QCoreApplication::translate("OpenWith::Editors", Constants::ASNEDITOR_DISPLAY_NAME));
+    addMimeType(Constants::ASN1_MIMETYPE);
+
+    setDocumentCreator([]() { return new AsnDocument; });
+    setEditorWidgetCreator([]() { return new AsnEditorWidget; });
+    setEditorCreator([]() { return new AsnEditor; });
+        // TODO setAutoCompleterCreator([]() { return new CppAutoCompleter; });
+    setCodeFoldingSupported(true);
+    setMarksVisible(true);
+    setParenthesesMatchingEnabled(true);
+
+    using namespace TextEditor;
+    setEditorActionHandlers(TextEditorActionHandler::Format
+                          | TextEditorActionHandler::UnCommentSelection
+                          | TextEditorActionHandler::UnCollapseAll
+                          | TextEditorActionHandler::FollowSymbolUnderCursor);
+
+  // TODO      addHoverHandler(new CppHoverHandler);
+}
+
+AsnEditorWidget::AsnEditorWidget()
+{
+ // TODO ? setLanguageSettingsId(Constants::SettingsId);
+
+    // TODO will probably be extracted to some asnacn base class
+    m_commentDefinition.multiLineStart.clear();
+    m_commentDefinition.multiLineEnd.clear();
+    m_commentDefinition.singleLine = QLatin1Literal("--");
+}
+
+void AsnEditorWidget::unCommentSelection()
+{
+    Utils::unCommentSelection(this, m_commentDefinition);
+}

--- a/asneditor.h
+++ b/asneditor.h
@@ -25,15 +25,39 @@
 
 #pragma once
 
+#include <texteditor/texteditor.h>
+
+#include <utils/uncommentselection.h>
+
 namespace Asn1Acn {
-namespace Constants {
+namespace Internal {
 
-const char LANG_ASN1[] = "ASN.1";
+class AsnEditor : public TextEditor::BaseTextEditor
+{
+    Q_OBJECT
 
-const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
-const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
+public:
+    explicit AsnEditor();
+};
 
-const char ASN1_MIMETYPE[] = "text/x-asn1";
+class AsnEditorFactory : public TextEditor::TextEditorFactory
+{
+public:
+    explicit AsnEditorFactory();
+};
 
+class AsnEditorWidget : public TextEditor::TextEditorWidget
+{
+    Q_OBJECT
+
+public:
+    explicit AsnEditorWidget();
+
+    void unCommentSelection() override;
+
+private:
+    Utils::CommentDefinition m_commentDefinition;
+};
+
+} // namespace Internal
 } // namespace Asn1Acn
-} // namespace Constants


### PR DESCRIPTION
* "Open with" have now "ASN.1 Editor" option for ".asn" and ".asn1" files
* In asn files "toggle comment (Ctrl+/)" works (and only that)

seems like a good starting point.

AsnDocument will probably be the thing shared between editor/outline/etc.

I'm not entirely happy with file names etc., but I tried to follow existing code conventions from QtCreator.