### PR TITLE
Asnide 15 autocomplete placeholder

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -31,7 +31,8 @@ SOURCES += \
     asn1acn.cpp \
     asneditor.cpp \
     asndocument.cpp \
-    asnautocompleter.cpp
+    asnautocompleter.cpp \
+    asncompletionassist.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -39,7 +40,8 @@ HEADERS += \
     asn1acn.h \
     asneditor.h \
     asndocument.h \
-    asnautocompleter.h
+    asnautocompleter.h \
+    asncompletionassist.h
 
 DISTFILES += \
     LICENSE \

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -30,14 +30,16 @@ DEFINES += ASN1ACN_LIBRARY
 SOURCES += \
     asn1acn.cpp \
     asneditor.cpp \
-    asndocument.cpp
+    asndocument.cpp \
+    asnautocompleter.cpp
 
 HEADERS += \
     asn1acn_global.h \
     asn1acnconstants.h \
     asn1acn.h \
     asneditor.h \
-    asndocument.h
+    asndocument.h \
+    asnautocompleter.h
 
 DISTFILES += \
     LICENSE \

--- a/asnautocompleter.cpp
+++ b/asnautocompleter.cpp
@@ -1,0 +1,150 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+#include "asnautocompleter.h"
+
+#include <QTextCursor>
+
+using namespace Asn1Acn::Internal;
+
+AsnAutoCompleter::AsnAutoCompleter()
+{
+}
+
+bool AsnAutoCompleter::isInComment(const QTextCursor &cursor) const
+{
+    // TODO: This doesn't handle '--' inside quotes
+    QTextCursor moved = cursor;
+    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+    return moved.selectedText().contains(QLatin1Literal("--"));
+}
+
+bool AsnAutoCompleter::isInString(const QTextCursor &cursor) const
+{
+    // TODO: multiline strings in ASN?
+    // TODO: escaping string?
+    QTextCursor moved = cursor;
+    moved.movePosition(QTextCursor::StartOfLine);
+    const int positionInLine = cursor.position() - moved.position();
+    moved.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
+    const QString line = moved.selectedText();
+
+    bool isEscaped = false;
+    bool inString = false;
+    for (int i = 0; i < positionInLine; ++i) {
+        const QChar c = line.at(i);
+        if (c == QLatin1Char('\\') && !isEscaped)
+            isEscaped = true;
+        else if (c == QLatin1Char('"') && !isEscaped)
+            inString = !inString;
+        else
+            isEscaped = false;
+    }
+    return inString;
+}
+
+QString AsnAutoCompleter::insertMatchingBrace(const QTextCursor &cursor,
+                                              const QString &text,
+                                              QChar lookAhead,
+                                              bool skipChars,
+                                              int *skippedChars) const
+{
+    // TODO { } - probably in "paragraph about to end"
+    Q_UNUSED(cursor)
+    if (text.isEmpty())
+        return QString();
+    const QChar current = text.at(0);
+    switch (current.unicode()) {
+    case '(':
+        return QStringLiteral(")");
+
+    case ')':
+        if (current == lookAhead && skipChars)
+            ++*skippedChars;
+        break;
+
+    default:
+        break;
+    }
+
+    return QString();
+}
+
+QString AsnAutoCompleter::insertMatchingQuote(const QTextCursor &cursor,
+                                              const QString &text,
+                                              QChar lookAhead,
+                                              bool skipChars,
+                                              int *skippedChars) const
+{
+    Q_UNUSED(cursor)
+    static const QChar quote(QLatin1Char('"'));
+    if (text.isEmpty() || text != quote)
+        return QString();
+    if (lookAhead == quote && skipChars) {
+        ++*skippedChars;
+        return QString();
+    }
+    return quote;
+}
+/*
+ *TODO?
+int AsnAutoCompleter::paragraphSeparatorAboutToBeInserted(QTextCursor &cursor, const TextEditor::TabSettings &tabSettings)
+{
+    const QString line = cursor.block().text().trimmed();
+    if (line.contains(QRegExp(QStringLiteral("^(endfunction|endmacro|endif|endforeach|endwhile)\\w*\\("))))
+        tabSettings.indentLine(cursor.block(), tabSettings.indentationColumn(cursor.block().text()));
+    return 0;
+}
+*/
+
+bool AsnAutoCompleter::contextAllowsAutoBrackets(const QTextCursor &cursor,
+                                                 const QString &textToInsert) const
+{
+    if (textToInsert.isEmpty())
+        return false;
+
+    const QChar c = textToInsert.at(0);
+    if (c == QLatin1Char('(') || c == QLatin1Char(')'))
+        return !isInComment(cursor);
+    return false;
+}
+
+bool AsnAutoCompleter::contextAllowsAutoQuotes(const QTextCursor &cursor, const QString &textToInsert) const
+{
+    if (textToInsert.isEmpty())
+        return false;
+
+    const QChar c = textToInsert.at(0);
+    if (c == QLatin1Char('"'))
+        return !isInComment(cursor);
+    return false;
+}
+
+/*
+bool AsnAutoCompleter::contextAllowsElectricCharacters(const QTextCursor &cursor) const
+{
+// TODO ?
+    return !isInComment(cursor) && !isInString(cursor);
+}
+*/

--- a/asnautocompleter.h
+++ b/asnautocompleter.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <texteditor/autocompleter.h>
+
+namespace Asn1Acn {
+namespace Internal {
+
+class AsnAutoCompleter : public TextEditor::AutoCompleter
+{
+public:
+    AsnAutoCompleter();
+
+    bool isInComment(const QTextCursor &cursor) const override;
+    bool isInString(const QTextCursor &cursor) const override;
+    QString insertMatchingBrace(const QTextCursor &cursor,
+                                const QString &text,
+                                QChar lookAhead,
+                                bool skipChars,
+                                int *skippedChars) const override;
+    QString insertMatchingQuote(const QTextCursor &cursor,
+                                const QString &text,
+                                QChar lookAhead,
+                                bool skipChars,
+                                int *skippedChars) const override;
+    bool contextAllowsAutoBrackets(const QTextCursor &cursor, const QString &textToInsert) const override;
+    bool contextAllowsAutoQuotes(const QTextCursor &cursor, const QString &textToInsert) const override;
+};
+
+} // namespace Internal
+} // namespace Asn1Acn

--- a/asncompletionassist.cpp
+++ b/asncompletionassist.cpp
@@ -1,0 +1,105 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+#include "asncompletionassist.h"
+
+#include <coreplugin/id.h>
+
+#include <texteditor/codeassist/assistproposalitem.h>
+#include <texteditor/codeassist/genericproposal.h>
+#include <texteditor/codeassist/genericproposalmodel.h>
+
+#include "asn1acnconstants.h"
+
+using namespace Asn1Acn::Internal;
+
+AsnCompletionAssistProcessor::AsnCompletionAssistProcessor()
+  : m_memberIcon(QLatin1String(":/codemodel/images/member.png")) // TODO in C++ mode somehow icons are colored
+{
+    // TODO snippets setSnippetGroup(Constants::ASN1_SNIPPETS_GROUP_ID);
+}
+
+/*
+    : m_snippetCollector(QString(), QIcon(":/texteditor/images/snippet.png"))
+    , m_variableIcon(QLatin1String(":/codemodel/images/keyword.png"))
+ * */
+
+TextEditor::IAssistProposal *AsnCompletionAssistProcessor::perform(const TextEditor::AssistInterface *interface)
+{
+    // TODO Keyword*Processor stores interface in ScopedPointer, why?
+
+    if (interface->reason() == TextEditor::IdleEditor)
+        return nullptr;
+
+    // TODO ugly placeholder code for future refactor
+    QList<TextEditor::AssistProposalItemInterface *> proposals;
+
+    // TODO those should be somehow loaded from some global model
+    auto proposalItem = new TextEditor::AssistProposalItem;
+    proposalItem->setText("My-TestStructure");
+    proposalItem->setDetail("detail"); // optional
+    proposalItem->setIcon(m_memberIcon);
+    proposalItem->setOrder(0); // ?
+    proposals << proposalItem;
+    proposalItem = new TextEditor::AssistProposalItem;
+    proposalItem->setText("MyTestStructure");
+    proposalItem->setIcon(m_memberIcon);
+    proposals << proposalItem;
+    proposalItem = new TextEditor::AssistProposalItem;
+    proposalItem->setText(interface->fileName());
+    proposalItem->setIcon(m_memberIcon);
+    proposals << proposalItem;
+
+    TextEditor::GenericProposalModel *model = new TextEditor::GenericProposalModel;
+    model->loadContent(proposals);
+    TextEditor::IAssistProposal *proposal = new TextEditor::GenericProposal(findStartOfName(interface), model);
+    return proposal;
+}
+
+int AsnCompletionAssistProcessor::findStartOfName(const TextEditor::AssistInterface *interface) const
+{
+    int pos = interface->position();
+
+    QChar chr;
+    do {
+        chr = interface->characterAt(--pos);
+    } while (chr.isLetterOrNumber() || chr == QLatin1Char('-'));
+
+    return ++pos;
+}
+
+bool AsnCompletionAssistProvider::supportsEditor(Core::Id editorId) const
+{
+    return editorId == Constants::ASNEDITOR_ID;
+}
+
+TextEditor::IAssistProcessor *AsnCompletionAssistProvider::createProcessor() const
+{
+    return new AsnCompletionAssistProcessor;
+}
+
+bool AsnCompletionAssistProvider::isContinuationChar(const QChar &c) const
+{
+    return c.isLetterOrNumber() || c == QLatin1Char('-');
+}

--- a/asncompletionassist.h
+++ b/asncompletionassist.h
@@ -25,17 +25,38 @@
 
 #pragma once
 
+#include <QIcon>
+
+#include <texteditor/codeassist/assistinterface.h>
+#include <texteditor/codeassist/completionassistprovider.h>
+#include <texteditor/codeassist/iassistprocessor.h>
+
 namespace Asn1Acn {
-namespace Constants {
+namespace Internal {
 
-const char LANG_ASN1[] = "ASN.1";
+class AsnCompletionAssistProcessor : public TextEditor::IAssistProcessor
+{
+public:
+    AsnCompletionAssistProcessor();
 
-const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
-const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
+    TextEditor::IAssistProposal *perform(const TextEditor::AssistInterface *interface) override;
 
-const char ASN1_MIMETYPE[] = "text/x-asn1";
+private:
+    int findStartOfName(const TextEditor::AssistInterface *interface) const;
 
-const char ASN1_SNIPPETS_GROUP_ID[] = "ASN.1";
+    QIcon m_memberIcon;
+};
 
-} // namespace Asn1Acn
-} // namespace Constants
+class AsnCompletionAssistProvider : public TextEditor::CompletionAssistProvider
+{
+    Q_OBJECT
+
+public:
+    bool supportsEditor(Core::Id editorId) const override;
+    TextEditor::IAssistProcessor *createProcessor() const override;
+
+    bool isContinuationChar(const QChar &c) const override;
+};
+
+} // Internal
+} // Asn1Acn

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -32,6 +32,7 @@
 #include "asn1acnconstants.h"
 #include "asndocument.h"
 #include "asnautocompleter.h"
+#include "asncompletionassist.h"
 
 using namespace Asn1Acn::Internal;
 
@@ -49,7 +50,10 @@ AsnEditorFactory::AsnEditorFactory()
     setDocumentCreator([]() { return new AsnDocument; });
     setEditorWidgetCreator([]() { return new AsnEditorWidget; });
     setEditorCreator([]() { return new AsnEditor; });
+
+    setCompletionAssistProvider(new AsnCompletionAssistProvider);
     setAutoCompleterCreator([]() { return new AsnAutoCompleter; });
+
     setCodeFoldingSupported(true);
     setMarksVisible(true);
     setParenthesesMatchingEnabled(true);

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -31,6 +31,7 @@
 
 #include "asn1acnconstants.h"
 #include "asndocument.h"
+#include "asnautocompleter.h"
 
 using namespace Asn1Acn::Internal;
 
@@ -48,12 +49,12 @@ AsnEditorFactory::AsnEditorFactory()
     setDocumentCreator([]() { return new AsnDocument; });
     setEditorWidgetCreator([]() { return new AsnEditorWidget; });
     setEditorCreator([]() { return new AsnEditor; });
-        // TODO setAutoCompleterCreator([]() { return new CppAutoCompleter; });
+    setAutoCompleterCreator([]() { return new AsnAutoCompleter; });
     setCodeFoldingSupported(true);
     setMarksVisible(true);
     setParenthesesMatchingEnabled(true);
 
-    using namespace TextEditor;
+    using TextEditorActionHandler = TextEditor::TextEditorActionHandler;
     setEditorActionHandlers(TextEditorActionHandler::Format
                           | TextEditorActionHandler::UnCommentSelection
                           | TextEditorActionHandler::UnCollapseAll


### PR DESCRIPTION
So we have both: autocompleting "()" and completion - assist, with fixed suggestions (yet).

I'm not sure, should I add "code model" in this task or does separate one is needed (this is potential place for integration with asn1scc).