### PR TITLE
ASNIDE-13 Added 'jump to' placeholder with simple jumping capability

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -33,6 +33,8 @@
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
 
+#include <texteditor/texteditorconstants.h>
+
 #include <utils/mimetypes/mimedatabase.h>
 
 #include "asneditor.h"
@@ -66,6 +68,11 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
     Utils::MimeDatabase::addMimeTypes(":/asn1acn/asn1acn.mimetypes.xml");
 
     addAutoReleasedObject(new AsnEditorFactory);
+
+    Core::ActionContainer *contextMenu = Core::ActionManager::createMenu(Constants::M_CONTEXT);
+
+    Core::Command *cmd = Core::ActionManager::ActionManager::command(TextEditor::Constants::FOLLOW_SYMBOL_UNDER_CURSOR);
+    contextMenu->addAction(cmd);
 
     return true;
 }

--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -69,7 +69,7 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
 
     addAutoReleasedObject(new AsnEditorFactory);
 
-    Core::ActionContainer *contextMenu = Core::ActionManager::createMenu(Constants::M_CONTEXT);
+    Core::ActionContainer *contextMenu = Core::ActionManager::createMenu(Constants::CONTEXT_MENU);
 
     Core::Command *cmd = Core::ActionManager::ActionManager::command(TextEditor::Constants::FOLLOW_SYMBOL_UNDER_CURSOR);
     contextMenu->addAction(cmd);

--- a/asn1acnconstants.h
+++ b/asn1acnconstants.h
@@ -30,7 +30,7 @@ namespace Constants {
 
 const char LANG_ASN1[] = "ASN.1";
 
-const char M_CONTEXT[] = "Asn1Acn.ContextMenu";
+const char CONTEXT_MENU[] = "Asn1Acn.ContextMenu";
 const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
 const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
 

--- a/asn1acnconstants.h
+++ b/asn1acnconstants.h
@@ -30,6 +30,7 @@ namespace Constants {
 
 const char LANG_ASN1[] = "ASN.1";
 
+const char M_CONTEXT[] = "Asn1Acn.ContextMenu";
 const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
 const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
 

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -95,7 +95,7 @@ void AsnEditorWidget::contextMenuEvent(QContextMenuEvent *e)
 {
     QPointer<QMenu> menu(new QMenu(this));
 
-    ActionContainer *mcontext = ActionManager::actionContainer(Constants::M_CONTEXT);
+    ActionContainer *mcontext = ActionManager::actionContainer(Constants::CONTEXT_MENU);
     QMenu *contextMenu = mcontext->menu();
 
     foreach (QAction *action, contextMenu->actions()) {

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -117,25 +117,24 @@ AsnEditorWidget::Link AsnEditorWidget::findLinkAt(const QTextCursor &cursor,
     Q_UNUSED(inNextSplit);
 
     TextDocument *document = textDocument();
-    Link link(document->filePath().toString());
-
     if (document->characterAt(cursor.position()).isSpace())
-        return link;
+        return Link();
 
     QTextCursor tc = cursor;
     tc.select(QTextCursor::WordUnderCursor);
     if (!tc.hasSelection())
-        return link;
+        return Link();
 
+    Link link(document->filePath().toString());
     if (resolveTarget) {
         QTextDocumentFragment selectedText(tc);
         if (selectedText.isEmpty())
-            return link;
+            return Link();
 
         QString docText = document->plainText();
         int targetPos = docText.indexOf(selectedText.toPlainText());
         if (targetPos == -1)
-            return link;
+            return Link();
 
         convertPosition(targetPos, &link.targetLine, &link.targetColumn);
     } else {

--- a/asneditor.h
+++ b/asneditor.h
@@ -55,6 +55,12 @@ public:
 
     void unCommentSelection() override;
 
+protected:
+    void contextMenuEvent(QContextMenuEvent *) override;
+    Link findLinkAt(const QTextCursor &,
+                    bool resolveTarget = true,
+                    bool inNextSplit = false) override;
+
 private:
     Utils::CommentDefinition m_commentDefinition;
 };


### PR DESCRIPTION
'Jump to' action will be triggered in following cases: when 'CTRL + left click' will be used on any item, or after selecting 'Follow Symbol Under Cursor', which will work after choosing it from context menu shown after right click, or pressing F2 button. 

Moving the cursor over any word while pressing Ctrl button, will cause the whole word to be underlined. Triggering 'jump to' will move cursor to the first occurrence of the word in active file. Let assume that there is following test file used: 

1: Test      File
2: Test      File
3: Test      File
4: Test      File
5: Test      File
6: F
7: e

Triggering 'jump to' on any of the word 'Test' will move cursor to 'Test' in line 1. Triggering the action on letter 'F' will move cursor to word 'File' in line 1.  Triggering the action on letter 'e' will move cursor to word 'Test' in line 1, just in front of the letter 'e'.

Presented change also result in change in context menu shown after right click, which now has content similar as in cpp, in comparison to previous context menu, which was the same as for .txt files.  