### PR TITLE
[ASNIDE-17] Added AsnDocumentProcessor, AsnParsedDataStorage, AsnPars…

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -35,7 +35,11 @@ SOURCES += \
     asncompletionassist.cpp \
     asnoutline.cpp \
     asnhighlighter.cpp \
-    asnsnippetprovider.cpp
+    asnsnippetprovider.cpp \
+    asnoverviewmodel.cpp \
+    asndocumentprocessor.cpp \
+    asnparseddatastorage.cpp \
+    asnparseddocument.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -47,7 +51,11 @@ HEADERS += \
     asncompletionassist.h \
     asnoutline.h \
     asnhighlighter.h \
-    asnsnippetprovider.h
+    asnsnippetprovider.h \
+    asnoverviewmodel.h \
+    asndocumentprocessor.h \
+    asnparseddatastorage.h \
+    asnparseddocument.h
 
 DISTFILES += \
     LICENSE \

--- a/asndocument.cpp
+++ b/asndocument.cpp
@@ -31,7 +31,9 @@
 
 using namespace Asn1Acn::Internal;
 
-const int PROCESS_DOCUMENT_INTERVAL_MS = 1000;
+namespace {
+    const int PROCESS_DOCUMENT_INTERVAL_MS = 1000;
+} // Anonymous namespace
 
 AsnDocument::AsnDocument()
 {

--- a/asndocument.cpp
+++ b/asndocument.cpp
@@ -27,13 +27,25 @@
 
 #include "asnhighlighter.h"
 #include "asn1acnconstants.h"
+#include "asndocumentprocessor.h"
 
 using namespace Asn1Acn::Internal;
+
+const int PROCESS_DOCUMENT_INTERVAL_MS = 1000;
 
 AsnDocument::AsnDocument()
 {
     setId(Constants::ASNEDITOR_ID);
     setSyntaxHighlighter(new AsnHighlighter);
+
+    m_processorTimer.setSingleShot(true);
+    m_processorTimer.setInterval(PROCESS_DOCUMENT_INTERVAL_MS);
+
+    connect(&m_processorTimer, &QTimer::timeout,
+            this, &AsnDocument::processDocument, Qt::UniqueConnection);
+
+    connect(this, &IDocument::filePathChanged,
+            this, &AsnDocument::onFilePathChanged);
 
     /*
      * setSyntaxHighlighter(new CppHighlighter);
@@ -48,7 +60,27 @@ AsnDocument::AsnDocument()
             this, &CppEditorDocument::onAboutToReload);
     connect(this, &Core::IDocument::reloadFinished,
             this, &CppEditorDocument::onReloadFinished);
-    connect(this, &IDocument::filePathChanged,
-            this, &CppEditorDocument::onFilePathChanged);
      * **/
+}
+
+void AsnDocument::scheduleProcessDocument()
+{
+    m_processorTimer.start();
+}
+
+void AsnDocument::onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath)
+{
+    if (newPath.isEmpty() || newPath == oldPath)
+        return;
+
+    connect(this, &Core::IDocument::contentsChanged, this, &AsnDocument::scheduleProcessDocument);
+    scheduleProcessDocument();
+}
+
+void AsnDocument::processDocument()
+{
+    AsnDocumentProcessor docProcessor(*this);
+    connect(&docProcessor, &AsnDocumentProcessor::asnDocumentUpdated,
+            this, &AsnDocument::documentUpdated);
+    docProcessor.run();
 }

--- a/asndocumentprocessor.cpp
+++ b/asndocumentprocessor.cpp
@@ -1,0 +1,68 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asndocumentprocessor.h"
+
+#include <QRegularExpression>
+
+#include <utils/fileutils.h>
+
+#include "asnparseddatastorage.h"
+
+using namespace Asn1Acn::Internal;
+
+const QString SEPARATOR_REG_EXP("\\s");
+
+AsnDocumentProcessor::AsnDocumentProcessor(const TextEditor::TextDocument &doc) :
+    m_textDocument(doc.document()),
+    m_filePath((doc.filePath()).fileName())
+{
+}
+
+void AsnDocumentProcessor::run() const
+{
+    AsnParsedDataStorage *model = AsnParsedDataStorage::instance();
+
+    std::shared_ptr<AsnParsedDocument> doc = model->getDataForFile(m_filePath);
+    if (!doc || doc->getRevision() != m_textDocument->revision()) {
+        std::unique_ptr<AsnParsedDocument> asnFile(parse());
+        model->update(m_filePath, std::move(asnFile));
+    }
+
+    // emit after parsing is finished
+    emit asnDocumentUpdated(*m_textDocument);
+}
+
+std::unique_ptr<AsnParsedDocument> AsnDocumentProcessor::parse() const
+{
+    // In this place parsing procedure should be executed
+    QString docPlainText = m_textDocument->toPlainText();
+    QStringList splittedDoc = docPlainText.split(QRegularExpression(SEPARATOR_REG_EXP),
+                                                 QString::SkipEmptyParts);
+
+    return std::unique_ptr<AsnParsedDocument>(new AsnParsedDocument(m_filePath,
+                                                                    m_textDocument->revision(),
+                                                                    splittedDoc));
+}

--- a/asndocumentprocessor.cpp
+++ b/asndocumentprocessor.cpp
@@ -47,7 +47,7 @@ void AsnDocumentProcessor::run() const
 
     std::shared_ptr<AsnParsedDocument> doc = model->getDataForFile(m_filePath);
     if (!doc || doc->getRevision() != m_textDocument->revision()) {
-        std::unique_ptr<AsnParsedDocument> asnFile(parse());
+        auto asnFile = parse();
         model->update(m_filePath, std::move(asnFile));
     }
 

--- a/asndocumentprocessor.h
+++ b/asndocumentprocessor.h
@@ -25,31 +25,33 @@
 
 #pragma once
 
-#include <QTimer>
+#include <QString>
+#include <QTextDocument>
 
 #include <texteditor/textdocument.h>
 
-#include <utils/fileutils.h>
+#include <memory>
+
+#include "asnparseddocument.h"
 
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnDocument : public TextEditor::TextDocument
+class AsnDocumentProcessor : public QObject
 {
     Q_OBJECT
-
 public:
-    explicit AsnDocument();
-    void scheduleProcessDocument();
+    AsnDocumentProcessor(const TextEditor::TextDocument &doc);
+    void run() const;
 
 signals:
-    void documentUpdated(const QTextDocument &doc);
+    void asnDocumentUpdated(const QTextDocument &doc) const;
 
 private:
-    void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
-    void processDocument();
+    std::unique_ptr<AsnParsedDocument> parse() const;
 
-    QTimer m_processorTimer;
+    QTextDocument *m_textDocument;
+    QString m_filePath;
 };
 
 } // namespace Internal

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -39,6 +39,8 @@
 #include "asndocument.h"
 #include "asnautocompleter.h"
 #include "asncompletionassist.h"
+#include "asnparseddocument.h"
+#include "asnparseddatastorage.h"
 
 using namespace Asn1Acn::Internal;
 
@@ -84,11 +86,20 @@ AsnEditorWidget::AsnEditorWidget()
     m_commentDefinition.multiLineStart.clear();
     m_commentDefinition.multiLineEnd.clear();
     m_commentDefinition.singleLine = QLatin1Literal("--");
+
+    m_model = new AsnOverviewModel(this);
 }
 
 void AsnEditorWidget::unCommentSelection()
 {
     Utils::unCommentSelection(this, m_commentDefinition);
+}
+
+void AsnEditorWidget::finalizeInitialization()
+{
+    AsnDocument *doc = qobject_cast<AsnDocument *>(textDocument());
+    connect(doc, &AsnDocument::documentUpdated,
+            this, &AsnEditorWidget::onAsnDocumentUpdated);
 }
 
 void AsnEditorWidget::contextMenuEvent(QContextMenuEvent *e)
@@ -143,4 +154,23 @@ AsnEditorWidget::Link AsnEditorWidget::findLinkAt(const QTextCursor &cursor,
     }
 
     return link;
+}
+
+void AsnEditorWidget::onAsnDocumentUpdated(const QTextDocument &document)
+{
+    Q_UNUSED(document);
+
+    QString filePath = textDocument()->filePath().fileName();
+    AsnParsedDataStorage *storage = AsnParsedDataStorage::instance();
+
+    std::shared_ptr<AsnParsedDocument> parsedDocument = storage->getDataForFile(filePath);
+    if (parsedDocument == nullptr)
+        return;
+
+    m_model->setDocument(parsedDocument);
+}
+
+AsnOverviewModel *AsnEditorWidget::getOverviewModel() const
+{
+    return m_model;
 }

--- a/asneditor.h
+++ b/asneditor.h
@@ -29,6 +29,8 @@
 
 #include <utils/uncommentselection.h>
 
+#include "asnoverviewmodel.h"
+
 namespace Asn1Acn {
 namespace Internal {
 
@@ -54,6 +56,9 @@ public:
     explicit AsnEditorWidget();
 
     void unCommentSelection() override;
+    void finalizeInitialization() override;
+
+    AsnOverviewModel *getOverviewModel() const;
 
 protected:
     void contextMenuEvent(QContextMenuEvent *) override;
@@ -62,7 +67,10 @@ protected:
                     bool inNextSplit = false) override;
 
 private:
+    void onAsnDocumentUpdated(const QTextDocument &document);
+
     Utils::CommentDefinition m_commentDefinition;
+    AsnOverviewModel *m_model;
 };
 
 } // namespace Internal

--- a/asnoutline.h
+++ b/asnoutline.h
@@ -34,33 +34,6 @@
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnOutlineItemModel : public QAbstractItemModel
-{
-    Q_OBJECT
-public:
-    explicit AsnOutlineItemModel(QObject *parent = 0);
-    ~AsnOutlineItemModel();
-
-    QVariant data(const QModelIndex &index, int role) const override;
-    Qt::ItemFlags flags(const QModelIndex &index) const override;
-    QVariant headerData(int section,
-                        Qt::Orientation orientation,
-                        int role = Qt::DisplayRole) const override;
-    QModelIndex index(int row,
-                      int column,
-                      const QModelIndex &parent = QModelIndex()) const override;
-    QModelIndex parent(const QModelIndex &index) const override;
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-
-    void addEntry(const QString &entry);
-    void flushEntries(void);
-
-private:
-    QVariant *m_rootItem;
-    QList<QVariant *> m_itemsData;
-};
-
 class AsnOutlineTreeView : public Utils::NavigationTreeView
 {
     Q_OBJECT
@@ -80,12 +53,9 @@ public:
     void setCursorSynchronization(bool syncWithCursor) override;
 
 private:
-    void updateModel();
-
-private:
     AsnEditorWidget *m_editor;
     AsnOutlineTreeView *m_treeView;
-    AsnOutlineItemModel *m_model;
+    AsnOverviewModel *m_model;
 };
 
 class AsnOutlineWidgetFactory : public TextEditor::IOutlineWidgetFactory

--- a/asnoverviewmodel.cpp
+++ b/asnoverviewmodel.cpp
@@ -1,0 +1,111 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asnoverviewmodel.h"
+
+namespace Asn1Acn {
+namespace Internal {
+
+AsnOverviewModel::AsnOverviewModel(QObject *parent) :
+    QAbstractItemModel(parent),
+    m_rootItem(new QVariant()),
+    m_asnParsedDocument(nullptr)
+{
+}
+
+AsnOverviewModel::~AsnOverviewModel()
+{
+    delete m_rootItem;
+}
+
+int AsnOverviewModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 1;
+}
+
+QVariant AsnOverviewModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || role != Qt::DisplayRole)
+        return QVariant();
+
+    QVariant *item = static_cast<QVariant *>(index.internalPointer());
+
+    return *item;
+}
+
+Qt::ItemFlags AsnOverviewModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return 0;
+
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
+}
+
+QVariant AsnOverviewModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    Q_UNUSED(section);
+    Q_UNUSED(orientation);
+    Q_UNUSED(role);
+
+    return *m_rootItem;
+}
+
+QModelIndex AsnOverviewModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (!hasIndex(row, column, parent))
+        return QModelIndex();
+
+    if (!parent.isValid() && m_asnParsedDocument) {
+        QVariant *childItem = m_asnParsedDocument->at(row);
+        return createIndex(row, column, childItem);
+    }
+
+    return QModelIndex();
+}
+
+QModelIndex AsnOverviewModel::parent(const QModelIndex &index) const
+{
+    Q_UNUSED(index);
+    return QModelIndex();
+}
+
+int AsnOverviewModel::rowCount(const QModelIndex &parent) const
+{
+    if (!parent.isValid() && m_asnParsedDocument)
+        return m_asnParsedDocument->getCount();
+
+    return 0;
+}
+
+void AsnOverviewModel::setDocument(std::shared_ptr<AsnParsedDocument> file)
+{
+    beginResetModel();
+    m_asnParsedDocument = file;
+    endResetModel();
+}
+
+} // namespace Internal
+} // namespace Asn1Acn

--- a/asnoverviewmodel.h
+++ b/asnoverviewmodel.h
@@ -25,31 +25,37 @@
 
 #pragma once
 
-#include <QTimer>
+#include <utils/navigationtreeview.h>
 
-#include <texteditor/textdocument.h>
+#include <memory>
 
-#include <utils/fileutils.h>
+#include "asnparseddocument.h"
 
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnDocument : public TextEditor::TextDocument
+class AsnOverviewModel : public QAbstractItemModel
 {
     Q_OBJECT
-
 public:
-    explicit AsnDocument();
-    void scheduleProcessDocument();
+    explicit AsnOverviewModel(QObject *parent = 0);
+    ~AsnOverviewModel();
 
-signals:
-    void documentUpdated(const QTextDocument &doc);
+    QVariant data(const QModelIndex &index, int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column,
+                      const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    void setDocument(std::shared_ptr<AsnParsedDocument> file);
 
 private:
-    void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
-    void processDocument();
-
-    QTimer m_processorTimer;
+    QVariant *m_rootItem;
+    std::shared_ptr<AsnParsedDocument> m_asnParsedDocument;
 };
 
 } // namespace Internal

--- a/asnparseddatastorage.h
+++ b/asnparseddatastorage.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <QHash>
+#include <QMutex>
 #include <QString>
 
 #include <memory>
@@ -48,6 +49,7 @@ public:
 
 private:
     QHash<QString, std::shared_ptr<AsnParsedDocument> > m_items;
+    mutable QMutex m_itemsMutex;
 };
 
 } // namespace Internal

--- a/asnparseddatastorage.h
+++ b/asnparseddatastorage.h
@@ -25,31 +25,29 @@
 
 #pragma once
 
-#include <QTimer>
+#include <QHash>
+#include <QString>
 
-#include <texteditor/textdocument.h>
+#include <memory>
 
-#include <utils/fileutils.h>
+#include "asnparseddocument.h"
 
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnDocument : public TextEditor::TextDocument
+class AsnParsedDataStorage
 {
-    Q_OBJECT
+    AsnParsedDataStorage() = default;
+    ~AsnParsedDataStorage() = default;
 
 public:
-    explicit AsnDocument();
-    void scheduleProcessDocument();
+    static AsnParsedDataStorage *instance();
 
-signals:
-    void documentUpdated(const QTextDocument &doc);
+    std::shared_ptr<AsnParsedDocument> getDataForFile(const QString &filePath) const;
+    void update(const QString &fPath, std::unique_ptr<AsnParsedDocument> fileData);
 
 private:
-    void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
-    void processDocument();
-
-    QTimer m_processorTimer;
+    QHash<QString, std::shared_ptr<AsnParsedDocument> > m_items;
 };
 
 } // namespace Internal

--- a/asnparseddocument.cpp
+++ b/asnparseddocument.cpp
@@ -23,34 +23,41 @@
 **
 ****************************************************************************/
 
-#pragma once
+#include "asnparseddocument.h"
 
-#include <QTimer>
+using namespace Asn1Acn::Internal;
 
-#include <texteditor/textdocument.h>
-
-#include <utils/fileutils.h>
-
-namespace Asn1Acn {
-namespace Internal {
-
-class AsnDocument : public TextEditor::TextDocument
+AsnParsedDocument::AsnParsedDocument() :
+    m_filePath(QString()),
+    m_revision(-1)
 {
-    Q_OBJECT
+}
 
-public:
-    explicit AsnDocument();
-    void scheduleProcessDocument();
+AsnParsedDocument::AsnParsedDocument(const QString &filePath, int revision,
+                                     const QStringList &wordList) :
+    m_filePath(filePath),
+    m_revision(revision)
+{
+    foreach (const QString &entry, wordList)
+        m_dataItems.push_back(new QVariant(entry));
+}
 
-signals:
-    void documentUpdated(const QTextDocument &doc);
+AsnParsedDocument::~AsnParsedDocument()
+{
+    qDeleteAll(m_dataItems);
+}
 
-private:
-    void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
-    void processDocument();
+QVariant *AsnParsedDocument::at(int idx) const
+{
+    return idx < m_dataItems.size() ? m_dataItems[idx] : nullptr;
+}
 
-    QTimer m_processorTimer;
-};
+size_t AsnParsedDocument::getCount() const
+{
+    return m_dataItems.size();
+}
 
-} // namespace Internal
-} // namespace Asn1Acn
+int AsnParsedDocument::getRevision() const
+{
+    return m_revision;
+}

--- a/asnparseddocument.h
+++ b/asnparseddocument.h
@@ -25,31 +25,31 @@
 
 #pragma once
 
-#include <QTimer>
-
-#include <texteditor/textdocument.h>
-
-#include <utils/fileutils.h>
+#include <QString>
+#include <QVariant>
+#include <QList>
 
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnDocument : public TextEditor::TextDocument
+class AsnParsedDocument
 {
-    Q_OBJECT
-
 public:
-    explicit AsnDocument();
-    void scheduleProcessDocument();
+    AsnParsedDocument();
+    AsnParsedDocument(const QString &filePath, int revision, const QStringList &list);
+    ~AsnParsedDocument();
 
-signals:
-    void documentUpdated(const QTextDocument &doc);
+    QVariant *at(int idx) const;
+
+    size_t getCount() const;
+    void addEntry(const QString &entry);
+
+    int getRevision() const;
 
 private:
-    void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
-    void processDocument();
-
-    QTimer m_processorTimer;
+    QString m_filePath;
+    QList<QVariant *> m_dataItems;
+    int m_revision;
 };
 
 } // namespace Internal


### PR DESCRIPTION
…edDocument classes. Extracted AsnOutlineItemModel and renamed to AsnOverviewModel. Filled outline widget with better stubbs.

For now I decided it is better to finish the task 'as is' without adding planned AsnTypeAssignement class, since changes in this pull request are big and relevant enough. 

Now, the outline widget is filled with list of words present in file. Widget changes contents on document being edited. 

The flow of signals and objects possession differs in comparison to cpp as follows: 

_CppEditorWidget_ owns refernce to _CppEditorOutlineWidget_. _CppEditorOutlineWidget_ owns _OverviewModel_. On every new document update, new _CppEditorWidget_ is created. _CppEditor_ gets notifications on changes in document so the _CppEditorOutlineWidget_ updates _OverviewModel_. Update in _OverviewModel_ also triggers update in _OutlineModel_. This happens because _OverviewModel_ is shared between both _CppEditorOutlineWidget_ and _OutlineWidget_. _OutlineWidget_ on its creation receives refernce to _CppEditorWidget_, which has outline() function in its public API, so this way model can be shared among both outlines. 


