### PR TITLE
Asnide 12 create structures project tree view placeholder

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -40,6 +40,7 @@
 #include "asneditor.h"
 #include "asnoutline.h"
 #include "asnsnippetprovider.h"
+#include "asnstructuresview.h"
 
 #include "acneditor.h"
 
@@ -77,6 +78,7 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
 
     addAutoReleasedObject(new AsnEditorFactory);
     addAutoReleasedObject(new AsnOutlineWidgetFactory);
+    addAutoReleasedObject(new AsnStructuresViewFactory);
     addAutoReleasedObject(new AsnSnippetProvider);
 
     addAutoReleasedObject(new AcnEditorFactory);

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -67,7 +67,8 @@ SOURCES += \
     asnparseddatastorage.cpp \
     asnparseddocument.cpp \
     acnhighlighter.cpp \
-    highlighter.cpp
+    highlighter.cpp \
+    asnstructuresview.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -88,7 +89,8 @@ HEADERS += \
     asnparseddatastorage.h \
     asnparseddocument.h \
     acnhighlighter.h \
-    highlighter.h
+    highlighter.h \
+    asnstructuresview.h
 
 DISTFILES += \
     LICENSE \

--- a/asnparseddocument.h
+++ b/asnparseddocument.h
@@ -42,8 +42,6 @@ public:
     QVariant *at(int idx) const;
 
     size_t getCount() const;
-    void addEntry(const QString &entry);
-
     int getRevision() const;
 
 private:

--- a/asnstructuresview.cpp
+++ b/asnstructuresview.cpp
@@ -1,0 +1,94 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asnstructuresview.h"
+
+#include <QVBoxLayout>
+
+#include <coreplugin/idocument.h>
+#include <coreplugin/find/itemviewfind.h>
+#include <coreplugin/editormanager/editormanager.h>
+
+#include "asn1acnconstants.h"
+#include "asneditor.h"
+
+using namespace Asn1Acn::Internal;
+
+AsnStructuresTreeView::AsnStructuresTreeView(QWidget *parent) :
+    Utils::NavigationTreeView(parent)
+{
+}
+
+void AsnStructuresViewWidget::refreshModel()
+{
+    // TODO: this is stubbed implementation, to be replaced by real one
+    Core::IDocument *currentDoc = Core::EditorManager::currentDocument();
+    if (currentDoc == nullptr)
+        return;
+
+    QString fileName = currentDoc->filePath().toString();
+
+    std::shared_ptr<AsnParsedDocument> docPtr(new AsnParsedDocument(fileName,
+                                                                    -1,
+                                                                    QStringList(fileName)));
+
+    m_model->setDocument(docPtr);
+}
+
+void AsnStructuresViewWidget::onCurrentEditorChanged(Core::IEditor *editor)
+{
+    Q_UNUSED(editor);
+
+    refreshModel();
+}
+
+AsnStructuresViewWidget::AsnStructuresViewWidget() :
+    m_treeView(new AsnStructuresTreeView(this)),
+    m_model(new AsnOverviewModel)
+{
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->setMargin(0);
+    layout->setSpacing(0);
+    layout->addWidget(Core::ItemViewFind::createSearchableWrapper(m_treeView));
+    setLayout(layout);
+
+    refreshModel();
+    m_treeView->setModel(m_model);
+
+    connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
+            this, &AsnStructuresViewWidget::onCurrentEditorChanged);
+}
+
+AsnStructuresViewFactory::AsnStructuresViewFactory()
+{
+    setDisplayName(tr("Structures View"));
+    setPriority(500);
+    setId(Constants::ASN_STRUCTURES_VIEW_ID);
+}
+
+Core::NavigationView AsnStructuresViewFactory::createWidget()
+{
+    return Core::NavigationView(new AsnStructuresViewWidget);
+}

--- a/asnstructuresview.h
+++ b/asnstructuresview.h
@@ -25,34 +25,48 @@
 
 #pragma once
 
+#include <QWidget>
+
+#include <coreplugin/inavigationwidgetfactory.h>
+#include <coreplugin/editormanager/ieditor.h>
+
+#include <utils/navigationtreeview.h>
+
+#include "asnoverviewmodel.h"
+
 namespace Asn1Acn {
-namespace Constants {
+namespace Internal {
 
-// Shared constants
+class AsnStructuresTreeView : public Utils::NavigationTreeView
+{
+    Q_OBJECT
+public:
+    AsnStructuresTreeView(QWidget *parent);
+};
 
-const char CONTEXT_MENU[] = "Asn1Acn.ContextMenu";
+// TODO: AsnStructuresViewWidget class should share base class with AsnOverview
+class AsnStructuresViewWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    AsnStructuresViewWidget();
 
-// ASN1 constants
+private:
+    void onCurrentEditorChanged(Core::IEditor *editor);
+    void refreshModel();
 
-const char LANG_ASN1[] = "ASN.1";
+    Utils::NavigationTreeView *m_treeView;
+    AsnOverviewModel *m_model;
+};
 
-const char ASNEDITOR_ID[] = "Asn1Acn.AsnEditor";
-const char ASNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ASN.1 Editor");
+class AsnStructuresViewFactory : public Core::INavigationWidgetFactory
+{
+    Q_OBJECT
+public:
+    AsnStructuresViewFactory();
 
-const char ASN_STRUCTURES_VIEW_ID[] = "Asn1Acn.StructuresView";
+    Core::NavigationView createWidget() override;
+};
 
-const char ASN1_MIMETYPE[] = "text/x-asn1";
-
-const char ASN1_SNIPPETS_GROUP_ID[] = "ASN.1";
-
-// ACN constants
-
-const char LANG_ACN[] = "ACN";
-
-const char ACNEDITOR_ID[] = "Asn1Acn.AcnEditor";
-const char ACNEDITOR_DISPLAY_NAME[] = QT_TRANSLATE_NOOP("OpenWith::Editors", "ACN Editor");
-
-const char ACN_MIMETYPE[] = "text/x-acn";
-
+} // namespace Internal
 } // namespace Asn1Acn
-} // namespace Constants


### PR DESCRIPTION
There is full file path shown as the widget body. It is responsive to change in currently open document (which should not be, as the widget shall be rather connected with contents of the documents, but this way the widget looks 'alive'). The widget have much in common with Outline widget, but IMO it is better to create base class for both the widgets later. 