### PR TITLE
Asnide 19 connect asn.1 editor with project tree view

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -41,6 +41,7 @@
 #include "asnoutline.h"
 #include "asnsnippetprovider.h"
 #include "asnstructuresview.h"
+#include "projectwatcher.h"
 
 #include "acneditor.h"
 
@@ -82,6 +83,8 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
     addAutoReleasedObject(new AsnSnippetProvider);
 
     addAutoReleasedObject(new AcnEditorFactory);
+
+    addAutoReleasedObject(new ProjectWatcher);
 
     Core::ActionContainer *contextMenu = Core::ActionManager::createMenu(Constants::CONTEXT_MENU);
 

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -69,7 +69,8 @@ SOURCES += \
     acnhighlighter.cpp \
     highlighter.cpp \
     asnstructuresview.cpp \
-    astxmlparser.cpp
+    astxmlparser.cpp \
+    asnparsedobject.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -96,7 +97,8 @@ HEADERS += \
     data/sourcelocation.h \
     data/typeassignment.h \
     data/definitions.h \
-    data/modules.h
+    data/modules.h \
+    asnparsedobject.h
 
 DISTFILES += \
     LICENSE \

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -37,7 +37,8 @@ QTC_LIB_DEPENDS += \
 
 QTC_PLUGIN_DEPENDS += \
     texteditor \
-    coreplugin
+    coreplugin \
+    projectexplorer
 
 QTC_PLUGIN_RECOMMENDS += \
     # optional plugin dependencies. nothing here at this time
@@ -70,7 +71,8 @@ SOURCES += \
     highlighter.cpp \
     asnstructuresview.cpp \
     astxmlparser.cpp \
-    asnparsedobject.cpp
+    asnparsedobject.cpp \
+    projectwatcher.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -98,7 +100,8 @@ HEADERS += \
     data/typeassignment.h \
     data/definitions.h \
     data/modules.h \
-    asnparsedobject.h
+    asnparsedobject.h \
+    projectwatcher.h
 
 DISTFILES += \
     LICENSE \

--- a/asndocument.cpp
+++ b/asndocument.cpp
@@ -46,7 +46,7 @@ AsnDocument::AsnDocument()
     connect(&m_processorTimer, &QTimer::timeout,
             this, &AsnDocument::processDocument, Qt::UniqueConnection);
 
-    connect(this, &IDocument::filePathChanged,
+    connect(this, &Core::IDocument::filePathChanged,
             this, &AsnDocument::onFilePathChanged);
 
     /*
@@ -75,14 +75,20 @@ void AsnDocument::onFilePathChanged(const Utils::FileName &oldPath, const Utils:
     if (newPath.isEmpty() || newPath == oldPath)
         return;
 
+    emit documentUpdated(*document());
+
     connect(this, &Core::IDocument::contentsChanged, this, &AsnDocument::scheduleProcessDocument);
-    scheduleProcessDocument();
 }
 
 void AsnDocument::processDocument()
 {
-    AsnDocumentProcessor docProcessor(*this);
+    QTextDocument *currentDocument = document();
+    AsnDocumentProcessor docProcessor(currentDocument,
+                                      filePath().toString(),
+                                      currentDocument->revision());
+
     connect(&docProcessor, &AsnDocumentProcessor::asnDocumentUpdated,
             this, &AsnDocument::documentUpdated);
+
     docProcessor.run();
 }

--- a/asndocumentprocessor.cpp
+++ b/asndocumentprocessor.cpp
@@ -42,9 +42,12 @@ using namespace Asn1Acn::Internal;
 static const QString SEPARATOR_REG_EXP("\\s");
 static const QString XML_VERSION_TAG("?xml version=\"1.0\"");
 
-AsnDocumentProcessor::AsnDocumentProcessor(const TextEditor::TextDocument &doc) :
-    m_textDocument(doc.document()),
-    m_filePath((doc.filePath()).fileName())
+AsnDocumentProcessor::AsnDocumentProcessor(const QTextDocument *doc,
+                                           const QString &filePath,
+                                           int revision) :
+    m_textDocument(doc),
+    m_filePath(filePath),
+    m_revision(revision)
 {
 }
 
@@ -52,19 +55,13 @@ void AsnDocumentProcessor::run() const
 {
     AsnParsedDataStorage *model = AsnParsedDataStorage::instance();
 
-    std::shared_ptr<AsnParsedDocument> doc = model->getDataForFile(m_filePath);
-    if (!doc || doc->getRevision() != m_textDocument->revision()) {
-        std::unique_ptr<AsnParsedDocument> file;
-
-        QTextCursor coursor = m_textDocument->find(XML_VERSION_TAG);
-        if (coursor.isNull())
-            file = parse();
-        else
-            file = parseFromXml();
-
-        model->update(m_filePath, std::move(file));
+    std::shared_ptr<AsnParsedDocument> oldDoc = model->getDataForFile(m_filePath);
+    if (!oldDoc || oldDoc->getRevision() != m_revision) {
+        std::unique_ptr<AsnParsedDocument> newDoc = parse();
+        model->addFile(m_filePath, std::move(newDoc));
     }
 
+    // TODO: emit in AsnParsedDataStorage could be used?
     // emit after parsing is finished
     emit asnDocumentUpdated(*m_textDocument);
 }
@@ -72,13 +69,12 @@ void AsnDocumentProcessor::run() const
 std::unique_ptr<AsnParsedDocument> AsnDocumentProcessor::parse() const
 {
     // In this place parsing procedure should be executed
-    QString docPlainText = m_textDocument->toPlainText();
-    QStringList splittedDoc = docPlainText.split(QRegularExpression(SEPARATOR_REG_EXP),
-                                                 QString::SkipEmptyParts);
+    QTextCursor coursor = m_textDocument->find(XML_VERSION_TAG);
 
-    return std::unique_ptr<AsnParsedDocument>(new AsnParsedDocument(m_filePath,
-                                                                    m_textDocument->revision(),
-                                                                    splittedDoc));
+    if (!coursor.isNull())
+        return parseFromXml();
+
+    return parseStubbed();
 }
 
 std::unique_ptr<AsnParsedDocument> AsnDocumentProcessor::parseFromXml() const
@@ -94,4 +90,15 @@ std::unique_ptr<AsnParsedDocument> AsnDocumentProcessor::parseFromXml() const
     return std::unique_ptr<AsnParsedDocument>(new AsnParsedDocument(m_filePath,
                                                                     m_textDocument->revision(),
                                                                     std::move(parsedData)));
+}
+
+std::unique_ptr<AsnParsedDocument> AsnDocumentProcessor::parseStubbed() const
+{
+    QString docPlainText = m_textDocument->toPlainText();
+    QStringList splittedDoc = docPlainText.split(QRegularExpression(SEPARATOR_REG_EXP),
+                                                 QString::SkipEmptyParts);
+
+    return std::unique_ptr<AsnParsedDocument>(new AsnParsedDocument(m_filePath,
+                                                                    m_textDocument->revision(),
+                                                                    splittedDoc));
 }

--- a/asndocumentprocessor.h
+++ b/asndocumentprocessor.h
@@ -41,7 +41,7 @@ class AsnDocumentProcessor : public QObject
 {
     Q_OBJECT
 public:
-    AsnDocumentProcessor(const TextEditor::TextDocument &doc);
+    AsnDocumentProcessor(const QTextDocument *doc, const QString &filePath, int revision);
     void run() const;
 
 signals:
@@ -50,9 +50,11 @@ signals:
 private:
     std::unique_ptr<AsnParsedDocument> parse() const;
     std::unique_ptr<AsnParsedDocument> parseFromXml() const;
+    std::unique_ptr<AsnParsedDocument> parseStubbed() const;
 
-    QTextDocument *m_textDocument;
-    QString m_filePath;
+    const QTextDocument *m_textDocument;
+    const QString m_filePath;
+    const int m_revision;
 };
 
 } // namespace Internal

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -125,7 +125,7 @@ void AsnEditorWidget::onAsnDocumentUpdated(const QTextDocument &document)
 {
     Q_UNUSED(document);
 
-    QString filePath = textDocument()->filePath().fileName();
+    QString filePath = textDocument()->filePath().toString();
     AsnParsedDataStorage *storage = AsnParsedDataStorage::instance();
 
     std::shared_ptr<AsnParsedDocument> parsedDocument = storage->getDataForFile(filePath);

--- a/asneditor.cpp
+++ b/asneditor.cpp
@@ -132,7 +132,7 @@ void AsnEditorWidget::onAsnDocumentUpdated(const QTextDocument &document)
     if (parsedDocument == nullptr)
         return;
 
-    m_model->setDocument(parsedDocument);
+    m_model->setRootNode(parsedDocument->getTreeRoot());
 }
 
 AsnOverviewModel *AsnEditorWidget::getOverviewModel() const

--- a/asnoutline.cpp
+++ b/asnoutline.cpp
@@ -62,6 +62,11 @@ void AsnOutlineTreeView::contextMenuEvent(QContextMenuEvent *event)
     event->accept(); */
 }
 
+void AsnOutlineWidget::modelUpdated()
+{
+    m_treeView->expandAll();
+}
+
 AsnOutlineWidget::AsnOutlineWidget(AsnEditorWidget *editor) :
     TextEditor::IOutlineWidget(),
     m_editor(editor),
@@ -75,6 +80,9 @@ AsnOutlineWidget::AsnOutlineWidget(AsnEditorWidget *editor) :
     setLayout(layout);
 
     m_treeView->setModel(m_model);
+
+    connect(m_model, &QAbstractItemModel::modelReset, this, &AsnOutlineWidget::modelUpdated);
+    modelUpdated();
 }
 
 QList<QAction *> AsnOutlineWidget::filterMenuActions() const

--- a/asnoutline.h
+++ b/asnoutline.h
@@ -53,6 +53,8 @@ public:
     void setCursorSynchronization(bool syncWithCursor) override;
 
 private:
+    void modelUpdated();
+
     AsnEditorWidget *m_editor;
     AsnOutlineTreeView *m_treeView;
     AsnOverviewModel *m_model;

--- a/asnoverviewmodel.h
+++ b/asnoverviewmodel.h
@@ -51,11 +51,12 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    void setDocument(std::shared_ptr<AsnParsedDocument> file);
+    void setRootNode(std::shared_ptr<AsnParsedObject> root);
 
 private:
-    QVariant *m_rootItem;
-    std::shared_ptr<AsnParsedDocument> m_asnParsedDocument;
+    const AsnParsedObject *getValidNode(const QModelIndex &index) const;
+
+    std::shared_ptr<AsnParsedObject> m_rootItem;
 };
 
 } // namespace Internal

--- a/asnparseddatastorage.cpp
+++ b/asnparseddatastorage.cpp
@@ -59,8 +59,8 @@ AsnParsedDataStorage::getAllParsedFiles() const
     return m_items.values();
 }
 
-void AsnParsedDataStorage::update(const QString &filePath,
-                                  std::unique_ptr<AsnParsedDocument> newFile)
+void AsnParsedDataStorage::addFile(const QString &filePath,
+                                   std::unique_ptr<AsnParsedDocument> newFile)
 {
     QMutexLocker locker(&m_itemsMutex);
 
@@ -71,4 +71,21 @@ void AsnParsedDataStorage::update(const QString &filePath,
     }
 
     m_items.insert(filePath, std::move(newFile));
+
+    locker.unlock();
+
+    emit storageUpdated();
+}
+
+void AsnParsedDataStorage::removeFile(const QString &filePath)
+{
+    QMutexLocker locker(&m_itemsMutex);
+    if (m_items.contains(filePath) == false)
+        return;
+
+    m_items.remove(filePath);
+
+    locker.unlock();
+
+    emit storageUpdated();
 }

--- a/asnparseddatastorage.cpp
+++ b/asnparseddatastorage.cpp
@@ -51,6 +51,14 @@ AsnParsedDataStorage::getDataForFile(const QString &filePath) const
     return m_items.contains(filePath) ? m_items.value(filePath) : nullptr;
 }
 
+QList<std::shared_ptr<AsnParsedDocument> >
+AsnParsedDataStorage::getAllParsedFiles() const
+{
+    QMutexLocker locker(&m_itemsMutex);
+
+    return m_items.values();
+}
+
 void AsnParsedDataStorage::update(const QString &filePath,
                                   std::unique_ptr<AsnParsedDocument> newFile)
 {

--- a/asnparseddatastorage.h
+++ b/asnparseddatastorage.h
@@ -45,6 +45,8 @@ public:
     static AsnParsedDataStorage *instance();
 
     std::shared_ptr<AsnParsedDocument> getDataForFile(const QString &filePath) const;
+    QList<std::shared_ptr<AsnParsedDocument> > getAllParsedFiles() const;
+
     void update(const QString &fPath, std::unique_ptr<AsnParsedDocument> fileData);
 
 private:

--- a/asnparseddatastorage.h
+++ b/asnparseddatastorage.h
@@ -36,8 +36,10 @@
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnParsedDataStorage
+class AsnParsedDataStorage : public QObject
 {
+    Q_OBJECT
+
     AsnParsedDataStorage() = default;
     ~AsnParsedDataStorage() = default;
 
@@ -47,7 +49,11 @@ public:
     std::shared_ptr<AsnParsedDocument> getDataForFile(const QString &filePath) const;
     QList<std::shared_ptr<AsnParsedDocument> > getAllParsedFiles() const;
 
-    void update(const QString &fPath, std::unique_ptr<AsnParsedDocument> fileData);
+    void addFile(const QString &filePath, std::unique_ptr<AsnParsedDocument> fileData);
+    void removeFile(const QString &filePath);
+
+signals:
+    void storageUpdated();
 
 private:
     QHash<QString, std::shared_ptr<AsnParsedDocument> > m_items;

--- a/asnparseddocument.h
+++ b/asnparseddocument.h
@@ -26,8 +26,12 @@
 #pragma once
 
 #include <QString>
-#include <QVariant>
 #include <QList>
+
+#include "data/modules.h"
+#include "data/definitions.h"
+
+#include "asnparsedobject.h"
 
 namespace Asn1Acn {
 namespace Internal {
@@ -37,17 +41,20 @@ class AsnParsedDocument
 public:
     AsnParsedDocument();
     AsnParsedDocument(const QString &filePath, int revision, const QStringList &list);
-    ~AsnParsedDocument();
+    AsnParsedDocument(const QString &filePath,
+                      int revision,
+                      std::unique_ptr<Data::Modules> parsedData);
 
-    QVariant *at(int idx) const;
+    std::shared_ptr<AsnParsedObject> getTreeRoot();
 
-    size_t getCount() const;
     int getRevision() const;
 
 private:
     QString m_filePath;
-    QList<QVariant *> m_dataItems;
     int m_revision;
+
+    std::shared_ptr<AsnParsedObject> m_parsedTreeRoot;
+    std::unique_ptr<Data::Modules> parsedData;
 };
 
 } // namespace Internal

--- a/asnparsedobject.cpp
+++ b/asnparsedobject.cpp
@@ -1,0 +1,95 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asnparsedobject.h"
+
+#include "utils/qtcassert.h"
+
+using namespace Asn1Acn::Internal;
+
+AsnParsedObject::AsnParsedObject(const QVariant& data) :
+    m_data(data),
+    m_parent(nullptr)
+{
+}
+
+AsnParsedObject::~AsnParsedObject()
+{
+    detachChildren();
+}
+
+int AsnParsedObject::childrenCount() const
+{
+    return m_children.count();
+}
+
+AsnParsedObject* AsnParsedObject::childAt(int idx) const
+{
+    return idx < m_children.size() ? m_children[idx].get() : nullptr;
+}
+
+void AsnParsedObject::addChild(std::shared_ptr<AsnParsedObject> child)
+{
+    QTC_ASSERT(child->m_parent == this || child->m_parent == nullptr, return);
+
+    m_children.push_back(child);
+    child->m_parent = this;
+}
+
+void AsnParsedObject::detachChildren()
+{
+    foreach (std::shared_ptr<AsnParsedObject> child, m_children)
+        child->m_parent = nullptr;
+
+    m_children.clear();
+}
+
+const QVariant &AsnParsedObject::data() const
+{
+    return m_data;
+}
+
+const AsnParsedObject* AsnParsedObject::parent() const
+{
+    return m_parent;
+}
+
+int AsnParsedObject::columnCount() const
+{
+    return 1;
+}
+
+int AsnParsedObject::row() const
+{
+    int idx = 0;
+    foreach (const std::shared_ptr<AsnParsedObject> &obj, m_parent->m_children) {
+        if (obj.get() == this)
+            return idx;
+
+        idx++;
+    }
+
+    return 0;
+}

--- a/asnparsedobject.h
+++ b/asnparsedobject.h
@@ -25,34 +25,36 @@
 
 #pragma once
 
-#include <QString>
-#include <QTextDocument>
-
-#include <texteditor/textdocument.h>
-
 #include <memory>
 
-#include "asnparseddocument.h"
+#include <QVariant>
 
 namespace Asn1Acn {
 namespace Internal {
 
-class AsnDocumentProcessor : public QObject
+class AsnParsedObject
 {
-    Q_OBJECT
 public:
-    AsnDocumentProcessor(const TextEditor::TextDocument &doc);
-    void run() const;
+    AsnParsedObject() = default;
+    AsnParsedObject(const QVariant &data);
+    ~AsnParsedObject();
 
-signals:
-    void asnDocumentUpdated(const QTextDocument &doc) const;
+    int childrenCount() const;
+    AsnParsedObject *childAt(int idx) const;
+    void addChild(std::shared_ptr<AsnParsedObject> child);
+    void detachChildren();
 
-private:
-    std::unique_ptr<AsnParsedDocument> parse() const;
-    std::unique_ptr<AsnParsedDocument> parseFromXml() const;
+    const QVariant &data() const;
 
-    QTextDocument *m_textDocument;
-    QString m_filePath;
+    const AsnParsedObject *parent() const;
+
+    int columnCount() const;
+    int row() const;
+
+protected:
+    QVariant m_data;
+    AsnParsedObject *m_parent;
+    QList<std::shared_ptr<AsnParsedObject> > m_children;
 };
 
 } // namespace Internal

--- a/asnstructuresview.cpp
+++ b/asnstructuresview.cpp
@@ -31,7 +31,9 @@
 #include <coreplugin/find/itemviewfind.h>
 #include <coreplugin/editormanager/editormanager.h>
 
+#include "asnparseddatastorage.h"
 #include "asn1acnconstants.h"
+#include "asnparsedobject.h"
 #include "asneditor.h"
 
 using namespace Asn1Acn::Internal;
@@ -43,18 +45,14 @@ AsnStructuresTreeView::AsnStructuresTreeView(QWidget *parent) :
 
 void AsnStructuresViewWidget::refreshModel()
 {
-    // TODO: this is stubbed implementation, to be replaced by real one
-    Core::IDocument *currentDoc = Core::EditorManager::currentDocument();
-    if (currentDoc == nullptr)
-        return;
+    m_modelRoot->detachChildren();
 
-    QString fileName = currentDoc->filePath().toString();
+    AsnParsedDataStorage *instance = AsnParsedDataStorage::instance();
+    auto documents = instance->getAllParsedFiles();
+    for (const auto &document : documents)
+        m_modelRoot->addChild(document->getTreeRoot());
 
-    std::shared_ptr<AsnParsedDocument> docPtr(new AsnParsedDocument(fileName,
-                                                                    -1,
-                                                                    QStringList(fileName)));
-
-    m_model->setDocument(docPtr);
+    m_model->setRootNode(m_modelRoot);
 }
 
 void AsnStructuresViewWidget::onCurrentEditorChanged(Core::IEditor *editor)
@@ -66,7 +64,8 @@ void AsnStructuresViewWidget::onCurrentEditorChanged(Core::IEditor *editor)
 
 AsnStructuresViewWidget::AsnStructuresViewWidget() :
     m_treeView(new AsnStructuresTreeView(this)),
-    m_model(new AsnOverviewModel)
+    m_model(new AsnOverviewModel),
+    m_modelRoot(std::shared_ptr<AsnParsedObject>(new AsnParsedObject))
 {
     QVBoxLayout *layout = new QVBoxLayout;
     layout->setMargin(0);
@@ -79,6 +78,11 @@ AsnStructuresViewWidget::AsnStructuresViewWidget() :
 
     connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
             this, &AsnStructuresViewWidget::onCurrentEditorChanged);
+}
+
+AsnStructuresViewWidget::~AsnStructuresViewWidget()
+{
+    delete m_model;
 }
 
 AsnStructuresViewFactory::AsnStructuresViewFactory()

--- a/asnstructuresview.cpp
+++ b/asnstructuresview.cpp
@@ -55,11 +55,10 @@ void AsnStructuresViewWidget::refreshModel()
     m_model->setRootNode(m_modelRoot);
 }
 
-void AsnStructuresViewWidget::onCurrentEditorChanged(Core::IEditor *editor)
+void AsnStructuresViewWidget::dataModelUpdated()
 {
-    Q_UNUSED(editor);
-
     refreshModel();
+    m_treeView->expandAll();
 }
 
 AsnStructuresViewWidget::AsnStructuresViewWidget() :
@@ -76,8 +75,10 @@ AsnStructuresViewWidget::AsnStructuresViewWidget() :
     refreshModel();
     m_treeView->setModel(m_model);
 
-    connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
-            this, &AsnStructuresViewWidget::onCurrentEditorChanged);
+    connect(AsnParsedDataStorage::instance(), &AsnParsedDataStorage::storageUpdated,
+            this, &AsnStructuresViewWidget::dataModelUpdated);
+
+    m_treeView->expandAll();
 }
 
 AsnStructuresViewWidget::~AsnStructuresViewWidget()

--- a/asnstructuresview.h
+++ b/asnstructuresview.h
@@ -50,13 +50,16 @@ class AsnStructuresViewWidget : public QWidget
     Q_OBJECT
 public:
     AsnStructuresViewWidget();
+    ~AsnStructuresViewWidget();
 
 private:
     void onCurrentEditorChanged(Core::IEditor *editor);
     void refreshModel();
 
     Utils::NavigationTreeView *m_treeView;
+
     AsnOverviewModel *m_model;
+    std::shared_ptr<AsnParsedObject> m_modelRoot;
 };
 
 class AsnStructuresViewFactory : public Core::INavigationWidgetFactory

--- a/asnstructuresview.h
+++ b/asnstructuresview.h
@@ -55,6 +55,7 @@ public:
 private:
     void onCurrentEditorChanged(Core::IEditor *editor);
     void refreshModel();
+    void dataModelUpdated();
 
     Utils::NavigationTreeView *m_treeView;
 

--- a/projectwatcher.cpp
+++ b/projectwatcher.cpp
@@ -1,0 +1,128 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of Qt Creator.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 as published by the Free Software
+** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+****************************************************************************/
+
+#include "projectwatcher.h"
+
+#include <QRegularExpression>
+#include <QTextDocument>
+#include <QByteArray>
+#include <QString>
+
+#include <projectexplorer/session.h>
+
+#include "asndocumentprocessor.h"
+#include "asnparseddatastorage.h"
+
+using namespace Asn1Acn::Internal;
+
+ProjectWatcher::ProjectWatcher()
+{
+    ProjectExplorer::SessionManager *sessionManager = ProjectExplorer::SessionManager::instance();
+    connect(sessionManager, &ProjectExplorer::SessionManager::projectRemoved,
+            this, &ProjectWatcher::onProjectRemoved);
+
+    ProjectExplorer::ProjectTree *projectTree = ProjectExplorer::ProjectTree::instance();
+    connect(projectTree, &ProjectExplorer::ProjectTree::filesAboutToBeAdded,
+            this, &ProjectWatcher::onFilesAdded);
+
+    connect(projectTree, &ProjectExplorer::ProjectTree::filesAboutToBeRemoved,
+            this, &ProjectWatcher::onFilesRemoved);
+}
+
+void ProjectWatcher::onProjectRemoved(ProjectExplorer::Project *project)
+{
+    if (project == nullptr)
+        return;
+
+    QStringList validFilePaths = filterValidFiles(project->files(ProjectExplorer::Project::AllFiles));
+
+    removeFiles(validFilePaths);
+}
+
+void ProjectWatcher::onFilesAdded(ProjectExplorer::FolderNode *folder,
+                                  const QList<ProjectExplorer::FileNode *> &newFiles)
+{
+    Q_UNUSED(folder);
+
+    QStringList filePaths = getFilePaths(newFiles);
+    QStringList validFilePaths = filterValidFiles(filePaths);
+    processFiles(validFilePaths);
+}
+
+void ProjectWatcher::onFilesRemoved(ProjectExplorer::FolderNode *folder,
+                                    const QList<ProjectExplorer::FileNode *> &staleFiles)
+{
+    Q_UNUSED(folder);
+
+    QStringList filePaths = getFilePaths(staleFiles);
+    QStringList validFilePaths = filterValidFiles(filePaths);
+    removeFiles(validFilePaths);
+}
+
+QStringList ProjectWatcher::getFilePaths(const QList<ProjectExplorer::FileNode *> &fileNodes) const
+{
+    QStringList filePaths;
+    foreach (const ProjectExplorer::FileNode *file, fileNodes)
+        filePaths << file->filePath().toString();
+
+    return filePaths;
+}
+
+QStringList ProjectWatcher::filterValidFiles(const QStringList &allFiles) const
+{
+    // TODO: filtering should be performed using mimetypes?
+    return allFiles.filter(".asn");
+}
+
+void ProjectWatcher::processFiles(const QStringList &filePaths) const
+{
+    foreach (const QString &path, filePaths) {
+        auto doc = textDocumentFromPath(path);
+        AsnDocumentProcessor dp(doc.get(), path, -1);
+        dp.run();
+    }
+}
+
+void ProjectWatcher::removeFiles(const QStringList &filePaths) const
+{
+    AsnParsedDataStorage *storage = AsnParsedDataStorage::instance();
+    foreach (const QString &path, filePaths)
+        storage->removeFile(path);
+}
+
+std::unique_ptr<QTextDocument>
+ProjectWatcher::textDocumentFromPath(const QString &fileName) const
+{
+    QFile file(fileName);
+
+    auto textDocument = std::unique_ptr<QTextDocument>(new QTextDocument);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return nullptr;
+
+    QString docContent = QString::fromLatin1(file.readAll().data());
+    textDocument->setPlainText(docContent);
+
+    return std::move(textDocument);
+}

--- a/projectwatcher.h
+++ b/projectwatcher.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of Qt Creator.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 as published by the Free Software
+** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QFile>
+#include <QTextDocument>
+
+#include <projectexplorer/projectexplorer.h>
+#include <projectexplorer/projectnodes.h>
+#include <projectexplorer/projecttree.h>
+#include <projectexplorer/project.h>
+
+namespace Asn1Acn {
+namespace Internal {
+
+class ProjectWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    ProjectWatcher();
+
+private slots:
+    void onProjectRemoved(ProjectExplorer::Project *project);
+
+    void onFilesAdded(ProjectExplorer::FolderNode *folder,
+                      const QList<ProjectExplorer::FileNode *> &newFiles);
+    void onFilesRemoved(ProjectExplorer::FolderNode *folder,
+                        const QList<ProjectExplorer::FileNode *> &staleFiles);
+
+private:
+    QStringList getFilePaths(const QList<ProjectExplorer::FileNode *> &fileNodes) const;
+
+    void processFiles(const QStringList &filePaths) const;
+    void removeFiles(const QStringList &filePaths) const;
+
+    std::unique_ptr<QTextDocument> textDocumentFromPath(const QString &fileName) const;
+    QStringList filterValidFiles(const QStringList &allFiles) const;
+};
+
+} // namespace Internal
+} // namespace Asn1Acn


### PR DESCRIPTION
List of changes included in this review: 

- tree model used now is capable of storing actual trees (before it was more of a list). New class AsnParsedObject was created to help handle it. 
- the model was used in both outline widget and Structure View widget
- the example usage of AstXmlParser was included. 
- ProjectWatcher class was created, so documents are now parsed after opening project or modifying files list in project instead of performing parsing after document was opened in editor. 

Future improvements:

- There can't be more than one instance of StructuresView widget. This is because every instance creates its own root node with AsnParsedFile object instances as children. Since those are stored globally and can not have multiple parents, attemt to create second structures view fails StructuresView. The situation could be fixed with to store root node for StructuresView globally as well, so it could be shared among every entity that needs it, but IMHO it would be too much for a placeholder. 
- The data obtained from AstXmlParser was rewritten to AsnParsedObject instance. The resolution for the issue is to either make AstXmlParser data inherit from AsnParsedObject or to make AsnParsedObject keep instance of AstXmlParser data.