### PR TITLE
ASNIDE-39 - Added ASN.1/ACN support for new file wizard

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -28,6 +28,7 @@
 
 #include <coreplugin/icore.h>
 #include <coreplugin/icontext.h>
+#include <coreplugin/jsexpander.h>
 #include <coreplugin/actionmanager/actionmanager.h>
 #include <coreplugin/actionmanager/command.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
@@ -40,6 +41,7 @@
 #include "asnsnippetprovider.h"
 #include "structuresview.h"
 #include "projectwatcher.h"
+#include "asn1acnjsextension.h"
 
 #include "acneditor.h"
 
@@ -86,6 +88,8 @@ bool Asn1AcnPlugin::initialize(const QStringList &arguments, QString *errorStrin
 
     Core::Command *cmd = Core::ActionManager::ActionManager::command(TextEditor::Constants::FOLLOW_SYMBOL_UNDER_CURSOR);
     contextMenu->addAction(cmd);
+
+    Core::JsExpander::registerQObjectForJs(QLatin1String("Asn1Acn"), new Asn1AcnJsExtension);
 
     return true;
 }

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -127,7 +127,13 @@ HEADERS += \
 
 ### Static files ###
 
-STATIC_FILES += snippets/asn.xml
+STATIC_FILES += \
+    snippets/asn.xml \
+    templates/wizards/files/acn/wizard.json \
+    templates/wizards/files/acn/template.acn \
+    templates/wizards/files/asn1/wizard.json \
+    templates/wizards/files/asn1/template.asn
+
 STATIC_BASE = $$PWD
 STATIC_OUTPUT_BASE = $$IDE_DATA_PATH
 STATIC_INSTALL_BASE = $$INSTALL_DATA_PATH

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -75,7 +75,8 @@ SOURCES += \
     projectwatcher.cpp \
     overviewwidget.cpp \
     document.cpp \
-    modeltree.cpp
+    modeltree.cpp \
+    asn1acnjsextension.cpp
 
 HEADERS += \
     asn1acn_global.h \
@@ -107,7 +108,8 @@ HEADERS += \
     projectwatcher.h \
     overviewwidget.h \
     document.h \
-    modeltree.h
+    modeltree.h \
+    asn1acnjsextension.h
 
 DISTFILES += \
     LICENSE \

--- a/asn1acnconstants.h
+++ b/asn1acnconstants.h
@@ -31,6 +31,7 @@ namespace Constants {
 // Shared constants
 
 const char CONTEXT_MENU[] = "Asn1Acn.ContextMenu";
+const char WIZARD_CATEGORY[] = "O.Asn1Acn";
 
 // ASN1 constants
 

--- a/asn1acnjsextension.cpp
+++ b/asn1acnjsextension.cpp
@@ -1,0 +1,37 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "asn1acnjsextension.h"
+
+#include <utils/qtcassert.h>
+
+using namespace Asn1Acn::Internal;
+
+QString Asn1AcnJsExtension::firstLetterToUpper(QString in)
+{
+    QTC_ASSERT(in.isEmpty() == false, return QString());
+
+    return in.replace(0, 1, in.at(0).toUpper());
+}

--- a/asn1acnjsextension.h
+++ b/asn1acnjsextension.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.com/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QString>
+#include <QObject>
+
+namespace Asn1Acn {
+namespace Internal {
+
+class Asn1AcnJsExtension : public QObject
+{
+    Q_OBJECT
+
+public:
+    Asn1AcnJsExtension(QObject *parent = 0) : QObject(parent) { }
+
+    Q_INVOKABLE QString firstLetterToUpper(QString in);
+};
+
+} // namespace Internal
+} // namespace Asn1Acn

--- a/templates/wizards/files/acn/template.acn
+++ b/templates/wizards/files/acn/template.acn
@@ -1,3 +1,3 @@
-%{JS: Util.fileName('%{TargetPath}')} DEFINITIONS ::= BEGIN
+%{JS: Asn1Acn.firstLetterToUpper(Util.fileName('%{TargetPath}'))} DEFINITIONS ::= BEGIN
 
 END

--- a/templates/wizards/files/acn/template.acn
+++ b/templates/wizards/files/acn/template.acn
@@ -1,0 +1,3 @@
+%{JS: Util.fileName('%{TargetPath}')} DEFINITIONS ::= BEGIN
+
+END

--- a/templates/wizards/files/acn/wizard.json
+++ b/templates/wizards/files/acn/wizard.json
@@ -3,9 +3,9 @@
     "supportedProjectTypes": [ ],
     "id": "Z.ACN",
     "category": "O.Asn1Acn",
-    "trDescription": "Creates an ACN model.",
+    "trDescription": "Creates an ACN encoding model.",
     "trDisplayName": "ACN Model",
-    "trDisplayCategory": "ASN1/ACN",
+    "trDisplayCategory": "ASN.1/ACN",
     "enabled": "%{JS: [ %{Plugins} ].indexOf('ASN.1/ACN') >= 0}",
 
     "pages" :

--- a/templates/wizards/files/acn/wizard.json
+++ b/templates/wizards/files/acn/wizard.json
@@ -1,0 +1,36 @@
+{
+    "version": 1,
+    "supportedProjectTypes": [ ],
+    "id": "Z.ACN",
+    "category": "O.Asn1Acn",
+    "trDescription": "Creates an ACN model.",
+    "trDisplayName": "ACN Model",
+    "trDisplayCategory": "ASN1/ACN",
+    "enabled": "%{JS: [ %{Plugins} ].indexOf('ASN.1/ACN') >= 0}",
+
+    "pages" :
+    [
+        {
+            "trDisplayName": "Location",
+            "trShortTitle": "Location",
+            "typeId": "File"
+        },
+        {
+            "trDisplayName": "Project Management",
+            "trShortTitle": "Summary",
+            "typeId": "Summary"
+        }
+    ],
+    "generators" :
+    [
+        {
+            "typeId": "File",
+            "data":
+            {
+                "source": "template.acn",
+                "target": "%{JS: Util.fileName('%{TargetPath}', '%{JS: Util.preferredSuffix('text/x-acn')}')}",
+                "openInEditor": true
+            }
+        }
+    ]
+}

--- a/templates/wizards/files/asn1/template.asn
+++ b/templates/wizards/files/asn1/template.asn
@@ -1,4 +1,4 @@
-%{JS: Util.fileName('%{TargetPath}')} DEFINITIONS ::= BEGIN
+%{JS: Asn1Acn.firstLetterToUpper(Util.fileName('%{TargetPath}'))} DEFINITIONS ::= BEGIN
 
 END
 

--- a/templates/wizards/files/asn1/template.asn
+++ b/templates/wizards/files/asn1/template.asn
@@ -1,0 +1,4 @@
+%{JS: Util.fileName('%{TargetPath}')} DEFINITIONS ::= BEGIN
+
+END
+

--- a/templates/wizards/files/asn1/wizard.json
+++ b/templates/wizards/files/asn1/wizard.json
@@ -1,0 +1,54 @@
+{
+    "version": 1,
+    "supportedProjectTypes": [ ],
+    "id": "Z.ASN1",
+    "category": "O.Asn1Acn",
+    "trDescription": "Creates an ASN.1 model.",
+    "trDisplayName": "ASN.1 Model",
+    "trDisplayCategory": "ASN1/ACN",
+    "enabled": "%{JS: [ %{Plugins} ].indexOf('ASN.1/ACN') >= 0}",
+
+    "pages" :
+    [
+        {
+            "trDisplayName": "Location",
+            "trShortTitle": "Location",
+            "typeId": "File"
+        },
+        {
+            "trDisplayName": "File Extension",
+            "trShortTitle": "Extension",
+            "typeId": "Fields",
+            "data":
+            {
+                "name": "FileExtensionType",
+                "type": "ComboBox",
+                "data" :
+                {
+                    "items" :
+                    [
+                        { "trKey": "asn", "value": ".asn" },
+                        { "trKey": "asn1", "value": ".asn1" }
+                    ]
+                 }
+            }
+        },
+        {
+            "trDisplayName": "Project Management",
+            "trShortTitle": "Summary",
+            "typeId": "Summary"
+        }
+    ],
+    "generators" :
+    [
+        {
+            "typeId": "File",
+            "data":
+            {
+                "source": "template.asn",
+                "target": "%{JS: Util.fileName('%{TargetPath}', '%{FileExtensionType}')}",
+                "openInEditor": true
+            }
+        }
+    ]
+}

--- a/templates/wizards/files/asn1/wizard.json
+++ b/templates/wizards/files/asn1/wizard.json
@@ -5,7 +5,7 @@
     "category": "O.Asn1Acn",
     "trDescription": "Creates an ASN.1 model.",
     "trDisplayName": "ASN.1 Model",
-    "trDisplayCategory": "ASN1/ACN",
+    "trDisplayCategory": "ASN.1/ACN",
     "enabled": "%{JS: [ %{Plugins} ].indexOf('ASN.1/ACN') >= 0}",
 
     "pages" :


### PR DESCRIPTION
Support for Acn / Asn data models was added. User will be able to choose if new Asn file should have .asn or .asn1 extension. Contents of newly created files is to be agreed. 