### PR TITLE
ASNIDE-122 Fixed handling of file renaming

### DIFF
--- a/projectcontenthandler.h
+++ b/projectcontenthandler.h
@@ -55,8 +55,8 @@ private slots:
     void onFilesProcessingFinished(const QString &projectName);
 
 private:
-    void handleFilesAdded(const QString &projectName, const QStringList &filePaths);
-    void handleFilesRemoved(const QString &projectName, const QStringList &filePaths);
+    void removeStaleFiles(const QString &projectName, const QStringList &filePaths);
+    void addNewFiles(const QString &projectName, const QStringList &filePaths);
 
     QStringList getStaleFilesNames(const QString &projectName, const QStringList &filePaths) const;
 


### PR DESCRIPTION
In fact, after renaming a file project does not need to be rebuilt,  because it does not change contents of any file. Propsed solution does that anyway, to avoid exposing internal parts of model nodes and parsed documents. It is justified in my opinion, as renaming the file in IDE is rather rare event. 