### PR TITLE
ASNIDE-121 Allowed creating parsed documents with no data to fix mode…

### DIFF
--- a/completion/usertypesproposalsprovider.cpp
+++ b/completion/usertypesproposalsprovider.cpp
@@ -39,6 +39,9 @@ Proposals UserTypesProposalsProvider::createProposals() const
 {
     Proposals proposals;
 
+    if (m_data == nullptr)
+        return proposals;
+
     Data::Modules::DefinitionsMap::const_iterator defIt;
     for (defIt = m_data->definitions().begin(); defIt != m_data->definitions().end(); defIt++) {
 

--- a/documentprocessor.h
+++ b/documentprocessor.h
@@ -43,6 +43,14 @@ class DocumentProcessor : public QObject
 {
     Q_OBJECT
 public:
+
+    enum class State {
+        Unfinished,
+        Successful,
+        Failed,
+        Errored
+    };
+
     DocumentProcessor(const QString &projectName);
     ~DocumentProcessor();
 
@@ -50,15 +58,24 @@ public:
     void run();
     std::vector<std::unique_ptr<ParsedDocument>> takeResults();
 
+    State getState();
+
 signals:
     void processingFinished(const QString &projectName) const;
 
 private slots:
     void onBuilderFinished();
+    void onBuilderFailed();
+    void onBuilderErrored();
 
 private:
+    void createFallbackResults();
+
     QHash<QString, DocumentSourceInfo> m_documents;
     QString m_projectName;
+
+    std::vector<std::unique_ptr<ParsedDocument>> m_results;
+    State m_state;
 
     ParsedDocumentBuilder *m_docBuilder;
 };

--- a/parseddocument.cpp
+++ b/parseddocument.cpp
@@ -38,6 +38,12 @@ ParsedDocument::ParsedDocument(std::unique_ptr<Data::Modules> parsedData, const 
     populateReferences();
 }
 
+ParsedDocument::ParsedDocument(const DocumentSourceInfo &source) :
+    m_source(source),
+    m_parsedData(nullptr)
+{
+}
+
 const DocumentSourceInfo &ParsedDocument::source() const
 {
     return m_source;
@@ -45,6 +51,9 @@ const DocumentSourceInfo &ParsedDocument::source() const
 
 void ParsedDocument::bindModelTreeNode(ModelTreeNode::ModelTreeNodePtr moduleNode) const
 {
+    if (m_parsedData == nullptr)
+        return;
+
     Data::Modules::DefinitionsMap::const_iterator defIt = m_parsedData->definitions().begin();
     while (defIt != m_parsedData->definitions().end()) {
         auto definitionNode = createDefinition(defIt->second);
@@ -55,6 +64,9 @@ void ParsedDocument::bindModelTreeNode(ModelTreeNode::ModelTreeNodePtr moduleNod
 
 void ParsedDocument::populateReferences()
 {
+    if (m_parsedData == nullptr)
+        return;
+
     Data::Modules::DefinitionsMap::const_iterator defIt;
     for (defIt = m_parsedData->definitions().begin(); defIt != m_parsedData->definitions().end(); defIt++)
         populateReferencesFromModule(defIt->second);
@@ -119,6 +131,9 @@ Data::TypeReference ParsedDocument::getTypeReference(const int line, const int c
 Data::SourceLocation ParsedDocument::getDefinitionLocation(const QString &typeAssignmentName,
                                                            const QString &moduleName) const
 {
+    if (m_parsedData == nullptr)
+        return Data::SourceLocation();
+
     Data::Modules::DefinitionsMap::const_iterator defIt;
     for (defIt = m_parsedData->definitions().begin(); defIt != m_parsedData->definitions().end(); defIt++) {
 

--- a/parseddocument.h
+++ b/parseddocument.h
@@ -44,6 +44,7 @@ class ParsedDocument
 {
 public:
 
+    ParsedDocument(const DocumentSourceInfo &source);
     ParsedDocument(std::unique_ptr<Data::Modules> parsedData, const DocumentSourceInfo &source);
 
     const DocumentSourceInfo &source() const;

--- a/projectcontenthandler.h
+++ b/projectcontenthandler.h
@@ -72,6 +72,9 @@ private:
     void startProcessing(DocumentProcessor *dp);
     void allProcessingFinished();
 
+    void handleFilesProcesedWithSuccess(const QString &projectName, std::vector<std::unique_ptr<ParsedDocument>> parsedDocuments);
+    void handleFilesProcesedWithFailure(const QString &projectName, std::vector<std::unique_ptr<ParsedDocument>> parsedDocuments);
+
     ModelTree *m_tree;
     ParsedDataStorage *m_storage;
 


### PR DESCRIPTION
…l behaviour after validating project.

The issue here was that when project after opening in IDE was not valid (which should be understand as could not be compiled successfully with asn1scc) the data model became unresposive. The issue was fixed with allowing to create ParsedDocument instances with no parsed data. Such instances will be created when asn1scc does not succeed. This way file processing does not ends prematurely and all files, no matter if valid or invalid at the moment, are present in storage. The flaw is that some null checks was needed.