### PR TITLE
Asnide 125 qmake project asn1scc support

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -196,6 +196,9 @@ STATIC_FILES += \
     templates/wizards/projects/asn1acn/template.asn \
     templates/wizards/projects/asn1acn/template.acn \
     templates/wizards/projects/asn1acn/file.pro \
+    templates/wizards/projects/asn1acn/createSources.pri \
+    templates/wizards/projects/asn1acn/handleAsn1AcnBuild.pri \
+    templates/wizards/projects/asn1acn/createSourcesList.pri \
     templates/wizards/projects/asn1acn/CMakeLists.txt
 
 STATIC_BASE = $$PWD

--- a/templates/wizards/projects/asn1acn/createSources.pri
+++ b/templates/wizards/projects/asn1acn/createSources.pri
@@ -6,30 +6,25 @@ defineReplace(filterASN1ACNFiles) {
         extension = $$last(splitted)
 
         equals(extension, asn)|equals(extension, asn1)|equals(extension, acn) {
-            fileNames += $$file
+            fileNames += $${PWD}/$${file}
         }
     }
 
     return($$fileNames)
 }
 
-ASN1ACNFILES = $${filterASN1ACNFiles($${DISTFILES})}
+ASN1ACNFILES = $$filterASN1ACNFiles($${DISTFILES})
 
 prepare.target += prepare
 prepare.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$ASN1SCC_PRODUCTS_DIR)
-QMAKE_EXTRA_TARGETS += prepare
-PRE_TARGETDEPS += prepare
 
-asn1scc.name = ASN1SCC
-asn1scc.input = ASN1ACNFILES
-asn1scc.output = asn1scc.out
-asn1scc.commands = $$ASN1SCC -c ${QMAKE_FILE_IN} -o $$ASN1SCC_PRODUCTS_DIR
-asn1scc.variable_out = ASN1ACN_SOURCES
-asn1scc.depends += prepare
-asn1scc.CONFIG += combine target_predeps no_link
-QMAKE_EXTRA_COMPILERS += asn1scc
+runAsn1Scc.target += runAsn1Scc
+runAsn1Scc.commands += $$ASN1SCC -c $$ASN1ACNFILES -o $$ASN1SCC_PRODUCTS_DIR
+runAsn1Scc.depends += prepare
 
 cleanSources.target += cleanSources
 cleanSources.commands += $$QMAKE_DEL_TREE $$ASN1SCC_PRODUCTS_DIR
 clean.depends += cleanSources
-QMAKE_EXTRA_TARGETS += cleanSources clean
+
+QMAKE_EXTRA_TARGETS += prepare runAsn1Scc cleanSources clean
+PRE_TARGETDEPS += prepare runAsn1Scc

--- a/templates/wizards/projects/asn1acn/createSources.pri
+++ b/templates/wizards/projects/asn1acn/createSources.pri
@@ -1,3 +1,26 @@
+######################################################################
+# Copyright (C) 2017 N7 Mobile sp. z o. o.
+# Contact: http://n7mobile.pl/Space
+#
+# This file is part of ASN.1/ACN Plugin for QtCreator.
+#
+# Plugin was developed under a programme and funded by
+# European Space Agency.
+#
+# This Plugin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Plugin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
 defineReplace(filterASN1ACNFiles) {
     allFiles = $${1}
 
@@ -19,7 +42,7 @@ prepare.target += prepare
 prepare.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$ASN1SCC_PRODUCTS_DIR)
 
 runAsn1Scc.target += runAsn1Scc
-runAsn1Scc.commands += $$ASN1SCC -c $$ASN1ACNFILES -o $$ASN1SCC_PRODUCTS_DIR
+runAsn1Scc.commands += $$ASN1SCC -c -$${ASN1SCC_ENCODING_OPTIONS} $$ASN1ACNFILES -o $$ASN1SCC_PRODUCTS_DIR
 runAsn1Scc.depends += prepare
 
 cleanSources.target += cleanSources

--- a/templates/wizards/projects/asn1acn/createSources.pri
+++ b/templates/wizards/projects/asn1acn/createSources.pri
@@ -1,0 +1,35 @@
+defineReplace(filterASN1ACNFiles) {
+    allFiles = $${1}
+
+    for(file, allFiles) {
+        splitted = $$split(file, ".")
+        extension = $$last(splitted)
+
+        equals(extension, asn)|equals(extension, asn1)|equals(extension, acn) {
+            fileNames += $$file
+        }
+    }
+
+    return($$fileNames)
+}
+
+ASN1ACNFILES = $${filterASN1ACNFiles($${DISTFILES})}
+
+prepare.target += prepare
+prepare.commands += $$sprintf($$QMAKE_MKDIR_CMD, $$ASN1SCC_PRODUCTS_DIR)
+QMAKE_EXTRA_TARGETS += prepare
+PRE_TARGETDEPS += prepare
+
+asn1scc.name = ASN1SCC
+asn1scc.input = ASN1ACNFILES
+asn1scc.output = asn1scc.out
+asn1scc.commands = $$ASN1SCC -c ${QMAKE_FILE_IN} -o $$ASN1SCC_PRODUCTS_DIR
+asn1scc.variable_out = ASN1ACN_SOURCES
+asn1scc.depends += prepare
+asn1scc.CONFIG += combine target_predeps no_link
+QMAKE_EXTRA_COMPILERS += asn1scc
+
+cleanSources.target += cleanSources
+cleanSources.commands += $$QMAKE_DEL_TREE $$ASN1SCC_PRODUCTS_DIR
+clean.depends += cleanSources
+QMAKE_EXTRA_TARGETS += cleanSources clean

--- a/templates/wizards/projects/asn1acn/createSourcesList.pri
+++ b/templates/wizards/projects/asn1acn/createSourcesList.pri
@@ -1,0 +1,46 @@
+defineReplace(createFileNames) {
+    allFiles = $${1}
+
+    for(file, allFiles) {
+        splitted = $$split($$basename(file), ".")
+        extension = $$last(splitted)
+
+        equals(extension, asn)|equals(extension, asn1) {
+            fileNames += $$first(splitted)
+        }
+    }
+
+    return($$fileNames)
+}
+
+defineReplace(createHeadersList) {
+    headersNames = $${1}
+
+    for(name, headersNames) {
+        header = $${ASN1SCC_PRODUCTS_DIR}/$${name}.h
+        headers += $$header
+    }
+
+    return($$headers)
+}
+
+defineReplace(createSourcesList) {
+    sourcesNames = $${1}
+
+    for(name, sourcesNames) {
+        source = $${ASN1SCC_PRODUCTS_DIR}/$${name}.c
+        sources += $$source
+    }
+
+    return($$sources)
+}
+
+names = $$createFileNames($$DISTFILES)
+
+!isEmpty(names) {
+    PERSISTENT_HEADERS = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.h
+    PERSISTENT_SOURCES = $${ASN1SCC_PRODUCTS_DIR}/acn.c $${ASN1SCC_PRODUCTS_DIR}/asn1crt.c $${ASN1SCC_PRODUCTS_DIR}/real.c
+}
+
+SOURCES += $$createSourcesList($$names) $$PERSISTENT_SOURCES
+HEADERS += $$createHeadersList($$names) $$PERSISTENT_HEADERS

--- a/templates/wizards/projects/asn1acn/createSourcesList.pri
+++ b/templates/wizards/projects/asn1acn/createSourcesList.pri
@@ -1,8 +1,32 @@
+######################################################################
+# Copyright (C) 2017 N7 Mobile sp. z o. o.
+# Contact: http://n7mobile.pl/Space
+#
+# This file is part of ASN.1/ACN Plugin for QtCreator.
+#
+# Plugin was developed under a programme and funded by
+# European Space Agency.
+#
+# This Plugin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Plugin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
 defineReplace(createFileNames) {
     allFiles = $${1}
 
     for(file, allFiles) {
-        splitted = $$split($$basename(file), ".")
+        fileBaseName = $$basename(file)
+        splitted = $$split(fileBaseName, ".")
         extension = $$last(splitted)
 
         equals(extension, asn)|equals(extension, asn1) {
@@ -39,8 +63,14 @@ names = $$createFileNames($$DISTFILES)
 
 !isEmpty(names) {
     PERSISTENT_HEADERS = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.h
-    PERSISTENT_SOURCES = $${ASN1SCC_PRODUCTS_DIR}/acn.c $${ASN1SCC_PRODUCTS_DIR}/asn1crt.c $${ASN1SCC_PRODUCTS_DIR}/real.c
+    PERSISTENT_SOURCES = $${ASN1SCC_PRODUCTS_DIR}/asn1crt.c $${ASN1SCC_PRODUCTS_DIR}/real.c
+
+    equals(ASN1SCC_ENCODING_OPTIONS, ACN) {
+        PERSISTENT_SOURCES += $${ASN1SCC_PRODUCTS_DIR}/acn.c
+    }
 }
 
 SOURCES += $$createSourcesList($$names) $$PERSISTENT_SOURCES
 HEADERS += $$createHeadersList($$names) $$PERSISTENT_HEADERS
+
+INCLUDEPATH += $$ASN1SCC_PRODUCTS_DIR

--- a/templates/wizards/projects/asn1acn/file.pro
+++ b/templates/wizards/projects/asn1acn/file.pro
@@ -10,4 +10,6 @@ CONFIG -= qt
       else if ('%{AddAcnFile}' === 'true')
         'DISTFILES += \\\\ \n %{AcnFullFileName}'
       else
-        '' }
+        'DISTFILES += ' }
+
+include(handleAsn1AcnBuild.pri)

--- a/templates/wizards/projects/asn1acn/handleAsn1AcnBuild.pri
+++ b/templates/wizards/projects/asn1acn/handleAsn1AcnBuild.pri
@@ -1,5 +1,29 @@
-ASN1SCC = asn1.exe
-ASN1SCC_PRODUCTS_DIR = $${PWD}/asn1acnSources
+######################################################################
+# Copyright (C) 2017 N7 Mobile sp. z o. o.
+# Contact: http://n7mobile.pl/Space
+#
+# This file is part of ASN.1/ACN Plugin for QtCreator.
+#
+# Plugin was developed under a programme and funded by
+# European Space Agency.
+#
+# This Plugin is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Plugin is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
+isEmpty(ASN1SCC): ASN1SCC = asn1.exe
+isEmpty(ASN1SCC_PRODUCTS_DIR): ASN1SCC_PRODUCTS_DIR = $${OUT_PWD}/asn1acnSources
+isEmpty(ASN1SCC_ENCODING_OPTIONS): ASN1SCC_ENCODING_OPTIONS = ACN
 
 include(createSourcesList.pri)
 include(createSources.pri)

--- a/templates/wizards/projects/asn1acn/handleAsn1AcnBuild.pri
+++ b/templates/wizards/projects/asn1acn/handleAsn1AcnBuild.pri
@@ -1,0 +1,5 @@
+ASN1SCC = asn1.exe
+ASN1SCC_PRODUCTS_DIR = $${PWD}/asn1acnSources
+
+include(createSourcesList.pri)
+include(createSources.pri)

--- a/templates/wizards/projects/asn1acn/wizard.json
+++ b/templates/wizards/projects/asn1acn/wizard.json
@@ -107,6 +107,24 @@
                     "condition": "%{JS: '%{BuildSystem}' === 'qmake'}"
                 },
                 {
+                    "source": "handleAsn1AcnBuild.pri",
+                    "target": "handleAsn1AcnBuild.pri",
+                    "openAsProject": false,
+                    "condition": "%{JS: '%{BuildSystem}' === 'qmake'}"
+                },
+                {
+                    "source": "createSourcesList.pri",
+                    "target": "createSourcesList.pri",
+                    "openAsProject": false,
+                    "condition": "%{JS: '%{BuildSystem}' === 'qmake'}"
+                },
+                {
+                    "source": "createSources.pri",
+                    "target": "createSources.pri",
+                    "openAsProject": false,
+                    "condition": "%{JS: '%{BuildSystem}' === 'qmake'}"
+                },
+                {
                     "source": "CMakeLists.txt",
                     "openAsProject": true,
                     "condition": "%{JS: '%{BuildSystem}' === 'cmake'}"


### PR DESCRIPTION
The solution implemented uses the approach to create list of sources to be built prior to actual build. This approach turned out to be working. It has go some flaws, and some solutions could be discussed. Firstly, I decided to give up on from using QMAKE_EXTRA_COMPILERS construct. This is because it does not really match the needs of project. Using QMAKE_EXTRA_COMPILERS assumes, two scenarios: the one in which one input file is converted into other file (like tranforming .cpp files into .o files), and the other, in which set of files is combined into one result file (like combining .o files into runnable binary). Our case is neither of those, as we are using multiple input files to combine them into multiple output files, but without strict matching input files and output files, so using QMAKE_EXTRA_TARGETS seems more appropriate, as the whole process of building is more like calling one command only. The reason why I elaborate on this so much, is because using QMAKE_EXTRA_COMPILERS still can be used, and has got interesting side effect: files which are added as input to it, appear in "Sources" branch in project tree view (it is not removed from "Other Files" at the same time). Since it could be hard to add .asn/.acn files to any other list of files than DISTFILES it might be unexpected way to have .asn/.acn files present in SOURCES.

Other things that I feel obliged to mention:

- the warning about adding not existing file will be generated by qmake. This is because file names are added to source before actual creating the files. This could be supressed by creating file stubs along with file names, but I decided to leave it this way for now, as in case of some failure it will not be obfuscating the situation. 
- the fact that there are couple of .pri files makes a little mess in working directory IMO, but there is not much to do about it.