### PR TITLE
Asnide 137 highlighting item under cursor with tests

### DIFF
--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -60,6 +60,7 @@
 #ifdef WITH_TESTS
 #include "tests/astxmlparser_tests.h"
 #include "tests/overviewindexupdater_tests.h"
+#include "tests/structuresviewindexupdater_tests.h"
 #endif
 
 #include "asn1acn.h"
@@ -174,6 +175,7 @@ QList<QObject *> Asn1AcnPlugin::createTestObjects() const
     return QList<QObject *>()
             << new Tests::AstXmlParserTests
             << new Tests::OverviewIndexUpdaterTests
+            << new Tests::StructuresViewIndexUpdaterTests
                ;
 }
 #endif

--- a/asn1acn.cpp
+++ b/asn1acn.cpp
@@ -59,6 +59,7 @@
 
 #ifdef WITH_TESTS
 #include "tests/astxmlparser_tests.h"
+#include "tests/overviewindexupdater_tests.h"
 #endif
 
 #include "asn1acn.h"
@@ -172,6 +173,7 @@ QList<QObject *> Asn1AcnPlugin::createTestObjects() const
 {
     return QList<QObject *>()
             << new Tests::AstXmlParserTests
+            << new Tests::OverviewIndexUpdaterTests
                ;
 }
 #endif

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -180,12 +180,13 @@ equals(TEST, 1) {
 
 SOURCES += \
     tests/astxmlparser_tests.cpp \
-    tests/overviewindexupdater_tests.cpp
+    tests/overviewindexupdater_tests.cpp \
+    tests/structuresviewindexupdater_tests.cpp
 
 HEADERS += \
     tests/astxmlparser_tests.h \
-    tests/overviewindexupdater_tests.h
-
+    tests/overviewindexupdater_tests.h \
+    tests/structuresviewindexupdater_tests.h
 }
 
 ### Static files ###

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -179,10 +179,12 @@ DISTFILES += \
 equals(TEST, 1) {
 
 SOURCES += \
-    tests/astxmlparser_tests.cpp
+    tests/astxmlparser_tests.cpp \
+    tests/overviewindexupdater_tests.cpp
 
 HEADERS += \
-    tests/astxmlparser_tests.h
+    tests/astxmlparser_tests.h \
+    tests/overviewindexupdater_tests.h
 
 }
 

--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -99,7 +99,9 @@ SOURCES += \
     projectcontenthandler.cpp \
     indenter.cpp \
     tools.cpp \
-    linkcreator.cpp
+    linkcreator.cpp \
+    overviewindexupdater.cpp \
+    structuresviewindexupdater.cpp
 
 HEADERS += \
     completion/autocompleter.h \
@@ -157,7 +159,9 @@ HEADERS += \
     indenter.h \
     tr.h \
     linkcreator.h \
-    tools.h
+    tools.h \
+    overviewindexupdater.h \
+    structuresviewindexupdater.h
 
 FORMS += \
     options-pages/general.ui \

--- a/outline.cpp
+++ b/outline.cpp
@@ -48,9 +48,9 @@ OutlineWidget::OutlineWidget(EditorWidget *editor) :
     connect(m_model, &QAbstractItemModel::modelReset,
             this, &OutlineWidget::modelUpdated);
 
-    m_indexUpdater = new OverviewIndexUpdater(m_model);
+    m_indexUpdater = std::make_unique<OverviewIndexUpdater>(m_model);
 
-    connect(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated,
+    connect(m_indexUpdater.get(), &OverviewIndexUpdater::currentIndexUpdated,
             this, &OutlineWidget::updateSelectionInTree);
 
     m_indexUpdater->setEditor(m_editor);

--- a/outline.cpp
+++ b/outline.cpp
@@ -37,6 +37,7 @@
 #include "acneditor.h"
 
 #include "modeltree.h"
+#include "overviewindexupdater.h"
 
 using namespace Asn1Acn::Internal;
 
@@ -46,6 +47,13 @@ OutlineWidget::OutlineWidget(EditorWidget *editor) :
 {
     connect(m_model, &QAbstractItemModel::modelReset,
             this, &OutlineWidget::modelUpdated);
+
+    m_indexUpdater = new OverviewIndexUpdater(m_model);
+
+    connect(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated,
+            this, &OutlineWidget::updateSelectionInTree);
+
+    m_indexUpdater->setEditor(m_editor);
 
     if (ModelTree::instance()->isValid())
         modelUpdated();
@@ -58,7 +66,7 @@ void OutlineWidget::modelUpdated()
     ModelTreeNode::ModelTreeNodePtr documentNode = ModelTree::instance()->getAnyNodeForFilepath(path);
     m_model->setRootNode(documentNode);
 
-    m_treeView->expandAll();
+    OverviewWidget::modelUpdated();
 }
 
 bool OutlineWidgetFactory::supportsEditor(Core::IEditor *editor) const

--- a/overviewindexupdater.cpp
+++ b/overviewindexupdater.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "overviewindexupdater.h"
+
+#include <texteditor/texteditor.h>
+
+#include <coreplugin/editormanager/editormanager.h>
+
+#include <texteditor/textdocument.h>
+
+using namespace Asn1Acn::Internal;
+
+static const int UPDATE_INTERVAL_MS = 500;
+
+OverviewIndexUpdater::OverviewIndexUpdater(const OverviewModel *model)
+    : m_model(model), m_editorWidget(nullptr)
+{
+    createUpdateTimer();
+}
+
+void OverviewIndexUpdater::setEditor(TextEditor::TextEditorWidget *editorWidget)
+{
+    if (m_editorWidget != nullptr)
+        disconnect(m_editorWidget, &QPlainTextEdit::cursorPositionChanged,
+                   this, &OverviewIndexUpdater::onCursorPositionChanged);
+
+    m_editorWidget = editorWidget;
+
+    if (m_editorWidget != nullptr) {
+        connect(m_editorWidget, &QPlainTextEdit::cursorPositionChanged,
+                this, &OverviewIndexUpdater::onCursorPositionChanged);
+        m_updateIndexTimer->start();
+    } else {
+        emit currentIndexUpdated(QModelIndex());
+    }
+}
+
+void OverviewIndexUpdater::updateCurrentIndex()
+{
+    if (m_editorWidget == nullptr)
+        return;
+
+    updateNow();
+}
+
+void OverviewIndexUpdater::onCursorPositionChanged()
+{
+    m_updateIndexTimer->start();
+}
+
+void OverviewIndexUpdater::createUpdateTimer()
+{
+    m_updateIndexTimer = new QTimer(this);
+    m_updateIndexTimer->setObjectName("OverviewIndexUpdater::UpdateTimer");
+    m_updateIndexTimer->setSingleShot(true);
+    m_updateIndexTimer->setInterval(UPDATE_INTERVAL_MS);
+
+    connect(m_updateIndexTimer, &QTimer::timeout,
+            this, &OverviewIndexUpdater::onUpdateTimerTimeout);
+}
+
+void OverviewIndexUpdater::onUpdateTimerTimeout()
+{
+    updateNow();
+}
+
+void OverviewIndexUpdater::updateNow()
+{
+    m_updateIndexTimer->stop();
+
+    QModelIndex index = getTargetIndexFromFileIndex(getCurrentFileIndex());
+    emit currentIndexUpdated(index);
+}
+
+QModelIndex OverviewIndexUpdater::getCurrentFileIndex() const
+{
+    return QModelIndex();
+}
+
+QModelIndex OverviewIndexUpdater::getTargetIndexFromFileIndex(const QModelIndex &fileIndex) const
+{
+    int line = 0;
+    int column = 0;
+    m_editorWidget->convertPosition(m_editorWidget->position(), &line, &column);
+
+    for (int row = 0; row < m_model->rowCount(fileIndex); ++row) {
+        const QModelIndex moduleIndex = m_model->index(row, 0, fileIndex);
+        const QModelIndex index = getTargetIndexFromModuleIndex(moduleIndex, line);
+        if (index.isValid())
+            return index;
+    }
+
+    return fileIndex;
+}
+
+QModelIndex OverviewIndexUpdater::getTargetIndexFromModuleIndex(const QModelIndex &moduleIndex, int line) const
+{
+    for (int row = 0; row < m_model->rowCount(moduleIndex); ++row) {
+        const QModelIndex index = m_model->index(row, 0, moduleIndex);
+
+        const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+        const Data::SourceLocation location = symbol->getSourceLocation();
+        if (location.line() == line)
+            return index;
+    }
+
+    return QModelIndex();
+}

--- a/overviewindexupdater.h
+++ b/overviewindexupdater.h
@@ -25,50 +25,54 @@
 
 #pragma once
 
-#include <QModelIndex>
+#include <QObject>
+#include <QTimer>
+#include <QAbstractItemModel>
 
-#include <texteditor/ioutlinewidget.h>
+#include "coreplugin/editormanager/ieditor.h"
 
-#include <utils/navigationtreeview.h>
-
+#include "editor.h"
 #include "overviewmodel.h"
-#include "overviewindexupdater.h"
 
 namespace Asn1Acn {
 namespace Internal {
 
-class OverviewTreeView : public Utils::NavigationTreeView
+class OverviewIndexUpdater : public QObject
 {
     Q_OBJECT
+
 public:
-    OverviewTreeView(QWidget *parent);
+    OverviewIndexUpdater(const OverviewModel *model);
+    virtual ~OverviewIndexUpdater() = default;
 
-    void contextMenuEvent(QContextMenuEvent *event) override;
-};
+    void setEditor(TextEditor::TextEditorWidget *editorWidget);
+    void updateCurrentIndex();
 
-class OverviewWidget : public TextEditor::IOutlineWidget
-{
-    Q_OBJECT
-public:
-    OverviewWidget(OverviewModel *model);
-    ~OverviewWidget();
+public slots:
+    void onCursorPositionChanged();
 
-    QList<QAction *> filterMenuActions() const override;
-    void setCursorSynchronization(bool syncWithCursor) override;
+signals:
+    void currentIndexUpdated(const QModelIndex &modelIndex);
 
 protected:
-    void modelUpdated();
-    OverviewTreeView *m_treeView;
-    OverviewModel *m_model;
+    QModelIndex indexForPosition(const QModelIndex &rootIndex) const;
 
-    OverviewIndexUpdater *m_indexUpdater;
+    const OverviewModel *m_model;
+    TextEditor::TextEditorWidget *m_editorWidget;
 
-protected slots:
-    void updateSelectionInTree(const QModelIndex &index);
+private:
+    void updateNow();
 
-private slots:
-    void onItemActivated(const QModelIndex &index);
+    void createUpdateTimer();
+    void onUpdateTimerTimeout();
+
+    virtual QModelIndex getCurrentFileIndex() const;
+
+    QModelIndex getTargetIndexFromFileIndex(const QModelIndex &fileIndex) const;
+    QModelIndex getTargetIndexFromModuleIndex(const QModelIndex &moduleIndex, int line) const;
+
+    QTimer *m_updateIndexTimer;
 };
 
-} // namespace Internal
-} // namespace Asn1Acn
+} /* namespace Asn1Acn */
+} /* namespace Internal */

--- a/overviewwidget.cpp
+++ b/overviewwidget.cpp
@@ -80,11 +80,6 @@ OverviewWidget::OverviewWidget(OverviewModel *model) :
             this, &OverviewWidget::onItemActivated);
 }
 
-OverviewWidget::~OverviewWidget()
-{
-    delete m_indexUpdater;
-}
-
 QList<QAction *> OverviewWidget::filterMenuActions() const
 {
     return QList<QAction *>();

--- a/overviewwidget.cpp
+++ b/overviewwidget.cpp
@@ -80,6 +80,11 @@ OverviewWidget::OverviewWidget(OverviewModel *model) :
             this, &OverviewWidget::onItemActivated);
 }
 
+OverviewWidget::~OverviewWidget()
+{
+    delete m_indexUpdater;
+}
+
 QList<QAction *> OverviewWidget::filterMenuActions() const
 {
     return QList<QAction *>();
@@ -93,6 +98,7 @@ void OverviewWidget::setCursorSynchronization(bool syncWithCursor)
 void OverviewWidget::modelUpdated()
 {
     m_treeView->expandAll();
+    m_indexUpdater->updateCurrentIndex();
 }
 
 void OverviewWidget::onItemActivated(const QModelIndex &index)
@@ -106,4 +112,10 @@ void OverviewWidget::onItemActivated(const QModelIndex &index)
     Core::EditorManager::openEditorAt(location.path(),
                                       location.line(),
                                       location.column());
+}
+
+void OverviewWidget::updateSelectionInTree(const QModelIndex &index)
+{
+    m_treeView->setCurrentIndex(index);
+    m_treeView->scrollTo(index);
 }

--- a/overviewwidget.h
+++ b/overviewwidget.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QModelIndex>
 
 #include <texteditor/ioutlinewidget.h>
@@ -51,7 +53,6 @@ class OverviewWidget : public TextEditor::IOutlineWidget
     Q_OBJECT
 public:
     OverviewWidget(OverviewModel *model);
-    ~OverviewWidget();
 
     QList<QAction *> filterMenuActions() const override;
     void setCursorSynchronization(bool syncWithCursor) override;
@@ -61,7 +62,7 @@ protected:
     OverviewTreeView *m_treeView;
     OverviewModel *m_model;
 
-    OverviewIndexUpdater *m_indexUpdater;
+    std::unique_ptr<OverviewIndexUpdater> m_indexUpdater;
 
 protected slots:
     void updateSelectionInTree(const QModelIndex &index);

--- a/structuresview.cpp
+++ b/structuresview.cpp
@@ -25,8 +25,11 @@
 
 #include "structuresview.h"
 
+#include <coreplugin/editormanager/editormanager.h>
+
 #include "modeltree.h"
 #include "asn1acnconstants.h"
+#include "structuresviewindexupdater.h"
 
 using namespace Asn1Acn::Internal;
 
@@ -37,6 +40,8 @@ StructuresViewWidget::StructuresViewWidget() :
     auto modelRoot = instance->getModelTreeRoot();
 
     m_model->setRootNode(modelRoot);
+
+    m_indexUpdater = createIndexUpdater();
 
     connect(ModelTree::instance(), &ModelTree::modelAboutToUpdate,
             m_model, &OverviewModel::invalidated);
@@ -51,6 +56,19 @@ StructuresViewWidget::StructuresViewWidget() :
 StructuresViewWidget::~StructuresViewWidget()
 {
     delete m_model;
+}
+
+OverviewIndexUpdater *StructuresViewWidget::createIndexUpdater() const
+{
+    StructuresViewIndexUpdater *indexUpdater = new StructuresViewIndexUpdater(m_model);
+
+    connect(indexUpdater, &OverviewIndexUpdater::currentIndexUpdated,
+            this, &StructuresViewWidget::updateSelectionInTree);
+
+    connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
+            indexUpdater, &StructuresViewIndexUpdater::onEditorChanged);
+
+    return indexUpdater;
 }
 
 StructuresViewFactory::StructuresViewFactory()

--- a/structuresview.cpp
+++ b/structuresview.cpp
@@ -58,17 +58,17 @@ StructuresViewWidget::~StructuresViewWidget()
     delete m_model;
 }
 
-OverviewIndexUpdater *StructuresViewWidget::createIndexUpdater() const
+std::unique_ptr<OverviewIndexUpdater> StructuresViewWidget::createIndexUpdater() const
 {
-    StructuresViewIndexUpdater *indexUpdater = new StructuresViewIndexUpdater(m_model);
+    std::unique_ptr<StructuresViewIndexUpdater> indexUpdater = std::make_unique<StructuresViewIndexUpdater>(m_model);
 
-    connect(indexUpdater, &OverviewIndexUpdater::currentIndexUpdated,
+    connect(indexUpdater.get(), &OverviewIndexUpdater::currentIndexUpdated,
             this, &StructuresViewWidget::updateSelectionInTree);
 
     connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
-            indexUpdater, &StructuresViewIndexUpdater::onEditorChanged);
+            indexUpdater.get(), &StructuresViewIndexUpdater::onEditorChanged);
 
-    return indexUpdater;
+    return std::move(indexUpdater);
 }
 
 StructuresViewFactory::StructuresViewFactory()

--- a/structuresview.h
+++ b/structuresview.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <coreplugin/inavigationwidgetfactory.h>
 
 #include "overviewwidget.h"
@@ -40,7 +42,7 @@ public:
     ~StructuresViewWidget();
 
 private:
-    OverviewIndexUpdater *createIndexUpdater() const;
+    std::unique_ptr<OverviewIndexUpdater> createIndexUpdater() const;
 };
 
 class StructuresViewFactory : public Core::INavigationWidgetFactory

--- a/structuresview.h
+++ b/structuresview.h
@@ -38,6 +38,9 @@ class StructuresViewWidget : public OverviewWidget
 public:
     StructuresViewWidget();
     ~StructuresViewWidget();
+
+private:
+    OverviewIndexUpdater *createIndexUpdater() const;
 };
 
 class StructuresViewFactory : public Core::INavigationWidgetFactory

--- a/structuresviewindexupdater.cpp
+++ b/structuresviewindexupdater.cpp
@@ -1,0 +1,69 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "structuresviewindexupdater.h"
+
+#include <QAbstractItemModel>
+
+#include <texteditor/texteditor.h>
+#include <texteditor/textdocument.h>
+
+#include <utils/fileutils.h>
+
+using namespace Asn1Acn::Internal;
+
+StructuresViewIndexUpdater::StructuresViewIndexUpdater(const OverviewModel *model)
+    : OverviewIndexUpdater(model)
+{
+}
+
+QModelIndex StructuresViewIndexUpdater::getCurrentFileIndex() const
+{
+    return getIndexFromPath(m_editorWidget->textDocument()->filePath().toString());
+}
+
+QModelIndex StructuresViewIndexUpdater::getIndexFromPath(const QString &path) const
+{
+    QModelIndex rootIndex = m_model->index(0, 0, QModelIndex());
+
+    for (int row = 0; row < m_model->rowCount(rootIndex); ++row) {
+        const QModelIndex index = m_model->index(row, 0, rootIndex);
+        const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+        const Data::SourceLocation location = symbol->getSourceLocation();
+
+        if (location.path() == path)
+            return index;
+    }
+
+    return QModelIndex();
+}
+
+void StructuresViewIndexUpdater::onEditorChanged(Core::IEditor *editor)
+{
+    Q_UNUSED(editor);
+
+    TextEditor::TextEditorWidget *editorWidget = TextEditor::TextEditorWidget::currentTextEditorWidget();
+    setEditor(editorWidget);
+}

--- a/structuresviewindexupdater.h
+++ b/structuresviewindexupdater.h
@@ -25,50 +25,29 @@
 
 #pragma once
 
-#include <QModelIndex>
+#include <QString>
+#include <QAbstractItemModel>
 
-#include <texteditor/ioutlinewidget.h>
+#include "coreplugin/editormanager/ieditor.h"
 
-#include <utils/navigationtreeview.h>
-
-#include "overviewmodel.h"
 #include "overviewindexupdater.h"
+#include "overviewmodel.h"
 
 namespace Asn1Acn {
 namespace Internal {
 
-class OverviewTreeView : public Utils::NavigationTreeView
+class StructuresViewIndexUpdater : public OverviewIndexUpdater
 {
-    Q_OBJECT
 public:
-    OverviewTreeView(QWidget *parent);
+    StructuresViewIndexUpdater(const OverviewModel *model);
 
-    void contextMenuEvent(QContextMenuEvent *event) override;
+public slots:
+    void onEditorChanged(Core::IEditor *editor);
+
+private:
+    QModelIndex getCurrentFileIndex() const override;
+    QModelIndex getIndexFromPath(const QString &path) const;
 };
 
-class OverviewWidget : public TextEditor::IOutlineWidget
-{
-    Q_OBJECT
-public:
-    OverviewWidget(OverviewModel *model);
-    ~OverviewWidget();
-
-    QList<QAction *> filterMenuActions() const override;
-    void setCursorSynchronization(bool syncWithCursor) override;
-
-protected:
-    void modelUpdated();
-    OverviewTreeView *m_treeView;
-    OverviewModel *m_model;
-
-    OverviewIndexUpdater *m_indexUpdater;
-
-protected slots:
-    void updateSelectionInTree(const QModelIndex &index);
-
-private slots:
-    void onItemActivated(const QModelIndex &index);
-};
-
-} // namespace Internal
-} // namespace Asn1Acn
+} /* namespace Asn1Acn */
+} /* namespace Internal */

--- a/tests/overviewindexupdater_tests.cpp
+++ b/tests/overviewindexupdater_tests.cpp
@@ -1,0 +1,264 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "overviewindexupdater_tests.h"
+
+#include <QtTest>
+
+#include <QTest>
+#include <QSignalSpy>
+
+#include <texteditor/textdocument.h>
+
+using namespace Asn1Acn::Internal;
+using namespace Asn1Acn::Internal::Tests;
+
+static const int RESPONSE_WAIT_TIME_MS = 600;
+
+OverviewIndexUpdaterTests::OverviewIndexUpdaterTests(QObject *parent)
+    : QObject(parent)
+{
+    m_model = new OverviewModel;
+    m_model->setRootNode(createModelNodes());
+
+    m_indexUpdater = new OverviewIndexUpdater(m_model);
+
+    m_editorWidget = createEditorWidget();
+}
+
+OverviewIndexUpdaterTests::~OverviewIndexUpdaterTests()
+{
+    delete m_indexUpdater;
+    delete m_model;
+    delete m_editorWidget;
+}
+
+TextEditor::TextEditorWidget *OverviewIndexUpdaterTests::createEditorWidget()
+{
+    TextEditor::TextDocument *document = new TextEditor::TextDocument;
+    document->setPlainText("Test1 DEFINITIONS ::= BEGIN\n"
+                           "   Num1 ::= INTEGER (-100 .. 1000)\n"
+                           "   Num2 ::= INTEGER (0 .. 1000)\n"
+                           "END\n"
+                           "Test2 DEFINITIONS ::= BEGIN\n"
+                           "    Num3 ::= INTEGER (-100 .. 1000)\n"
+                           "    Num4 ::= INTEGER (0 .. 1000)\n"
+                           "END\n"
+                           "\n"
+                           "\n");
+
+    QSharedPointer<TextEditor::TextDocument> documentPointer(document);
+
+    TextEditor::TextEditorWidget *editorWidget = new TextEditor::TextEditorWidget;
+    editorWidget->setTextDocument(documentPointer);
+
+    return editorWidget;
+}
+
+ModelTreeNode::ModelTreeNodePtr OverviewIndexUpdaterTests::createModelNodes()
+{
+    ModelTreeNode::ModelTreeNodePtr rootNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode);
+
+    Data::SourceLocation location = Data::SourceLocation("", 0, 0);
+    ModelTreeNode::ModelTreeNodePtr moduleNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Module1", location));
+
+    location = Data::SourceLocation("", 2, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num1", location)));
+    location = Data::SourceLocation("", 3, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num2", location)));
+    rootNode->addChild(moduleNode);
+
+    location = Data::SourceLocation("", 0, 0);
+    moduleNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Module2", location));
+
+    location = Data::SourceLocation("", 6, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num3", location)));
+    location = Data::SourceLocation("", 7, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num4", location)));
+    rootNode->addChild(moduleNode);
+
+    return rootNode;
+}
+
+void OverviewIndexUpdaterTests::test_setEmptyEditor()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+
+    m_indexUpdater->setEditor(nullptr);
+
+    QCOMPARE(spy.count(), 1);
+
+    QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), false);
+}
+
+void OverviewIndexUpdaterTests::test_setNonEmpytEditorInitialCursorPosition()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+
+    m_editorWidget->gotoLine(0);
+    m_indexUpdater->setEditor(m_editorWidget);
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), false);
+}
+
+void OverviewIndexUpdaterTests::test_setNonEmpytEditorChangedPosition()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+    const int lineNumber = 2;
+
+    m_editorWidget->gotoLine(lineNumber);
+    m_indexUpdater->setEditor(m_editorWidget);
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), true);
+
+    const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+    const Data::SourceLocation location = symbol->getSourceLocation();
+    QCOMPARE(location.line(), lineNumber);
+}
+
+void OverviewIndexUpdaterTests::test_cursorMovedToModule()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+
+    m_editorWidget->gotoLine(1);
+    m_indexUpdater->setEditor(m_editorWidget);
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), false);
+}
+
+void OverviewIndexUpdaterTests::test_cursorMovedToTypeDefinition()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+    const int lineNumber = 3;
+
+    m_editorWidget->gotoLine(lineNumber);
+    m_indexUpdater->setEditor(m_editorWidget);
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), true);
+
+    const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+    const Data::SourceLocation location = symbol->getSourceLocation();
+    QCOMPARE(location.line(), lineNumber);
+}
+
+void OverviewIndexUpdaterTests::test_cursorMovedToEmptyLine()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+
+    m_editorWidget->gotoLine(8);
+    m_indexUpdater->setEditor(m_editorWidget);
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), false);
+}
+
+void OverviewIndexUpdaterTests::test_forceUpdate()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+    const int lineNumber = 6;
+
+    m_editorWidget->gotoLine(lineNumber);
+    m_indexUpdater->setEditor(m_editorWidget);
+    m_indexUpdater->updateCurrentIndex();
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), true);
+
+    const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+    const Data::SourceLocation location = symbol->getSourceLocation();
+    QCOMPARE(location.line(), lineNumber);
+}
+
+void OverviewIndexUpdaterTests::test_forceUpdateAfterCursorMoved()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+    const int lineNumber = 7;
+
+    m_indexUpdater->setEditor(m_editorWidget);
+    m_editorWidget->gotoLine(lineNumber);
+    m_indexUpdater->updateCurrentIndex();
+
+    QTest::qWait(RESPONSE_WAIT_TIME_MS);
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), true);
+
+    const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+    const Data::SourceLocation location = symbol->getSourceLocation();
+    QCOMPARE(location.line(), lineNumber);
+}

--- a/tests/overviewindexupdater_tests.cpp
+++ b/tests/overviewindexupdater_tests.cpp
@@ -110,10 +110,10 @@ void OverviewIndexUpdaterTests::test_setEmptyEditor()
 
     QCOMPARE(spy.count(), 1);
 
-    QVariant result = spy.at(0).at(0);
+    const QVariant result = spy.at(0).at(0);
     QCOMPARE(result.type(), QVariant::ModelIndex);
 
-    QModelIndex index = qvariant_cast<QModelIndex>(result);
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
     QCOMPARE(index.isValid(), false);
 }
 
@@ -128,10 +128,10 @@ void OverviewIndexUpdaterTests::test_setNonEmpytEditorInitialCursorPosition()
 
     QCOMPARE(spy.count(), 1);
 
-    QVariant result = spy.at(0).at(0);
+    const QVariant result = spy.at(0).at(0);
     QCOMPARE(result.type(), QVariant::ModelIndex);
 
-    QModelIndex index = qvariant_cast<QModelIndex>(result);
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
     QCOMPARE(index.isValid(), false);
 }
 

--- a/tests/overviewindexupdater_tests.h
+++ b/tests/overviewindexupdater_tests.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+#include "../overviewmodel.h"
+#include "../overviewindexupdater.h"
+
+#include "../modeltreenode.h"
+
+namespace Asn1Acn {
+namespace Internal {
+namespace Tests {
+
+class OverviewIndexUpdaterTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit OverviewIndexUpdaterTests(QObject *parent = 0);
+    ~OverviewIndexUpdaterTests();
+
+private slots:
+    void test_setEmptyEditor();
+    void test_setNonEmpytEditorInitialCursorPosition();
+    void test_setNonEmpytEditorChangedPosition();
+
+    void test_cursorMovedToModule();
+    void test_cursorMovedToTypeDefinition();
+    void test_cursorMovedToEmptyLine();
+
+    void test_forceUpdate();
+    void test_forceUpdateAfterCursorMoved();
+
+private:
+    ModelTreeNode::ModelTreeNodePtr createModelNodes();
+    TextEditor::TextEditorWidget *createEditorWidget();
+
+    OverviewModel *m_model;
+    OverviewIndexUpdater *m_indexUpdater;
+    TextEditor::TextEditorWidget *m_editorWidget;
+};
+
+} // namespace Tests
+} // namespace Internal
+} // namespace Asn1Acn

--- a/tests/structuresviewindexupdater_tests.cpp
+++ b/tests/structuresviewindexupdater_tests.cpp
@@ -1,0 +1,138 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "structuresviewindexupdater_tests.h"
+
+#include <QtTest>
+
+#include <QTest>
+#include <QSignalSpy>
+
+#include <texteditor/textdocument.h>
+#include <utils/fileutils.h>
+
+#include <QDebug>
+
+using namespace Asn1Acn::Internal;
+using namespace Asn1Acn::Internal::Tests;
+
+static const int RESPONSE_WAIT_TIME_MS = 600;
+static const QString FILE_PATH("/test/file1.asn");
+
+StructuresViewIndexUpdaterTests::StructuresViewIndexUpdaterTests(QObject *parent)
+    : QObject(parent)
+{
+    m_model = new OverviewModel;
+    m_model->setRootNode(createModelNodes());
+
+    m_indexUpdater = new StructuresViewIndexUpdater(m_model);
+
+    m_editorWidget = createEditorWidget();
+}
+
+StructuresViewIndexUpdaterTests::~StructuresViewIndexUpdaterTests()
+{
+    delete m_indexUpdater;
+    delete m_model;
+    delete m_editorWidget;
+}
+
+TextEditor::TextEditorWidget *StructuresViewIndexUpdaterTests::createEditorWidget()
+{
+    TextEditor::TextDocument *document = new TextEditor::TextDocument;
+    document->setPlainText("Test1 DEFINITIONS ::= BEGIN\n"
+                           "   Num1 ::= INTEGER (-100 .. 1000)\n"
+                           "   Num2 ::= INTEGER (0 .. 1000)\n"
+                           "END\n"
+                           "Test2 DEFINITIONS ::= BEGIN\n"
+                           "    Num3 ::= INTEGER (-100 .. 1000)\n"
+                           "    Num4 ::= INTEGER (0 .. 1000)\n"
+                           "END\n"
+                           "\n"
+                           "\n");
+
+    document->setFilePath(Utils::FileName::fromString(FILE_PATH));
+
+    QSharedPointer<TextEditor::TextDocument> documentPointer(document);
+
+    TextEditor::TextEditorWidget *editorWidget = new TextEditor::TextEditorWidget;
+    editorWidget->setTextDocument(documentPointer);
+
+    return editorWidget;
+}
+
+ModelTreeNode::ModelTreeNodePtr StructuresViewIndexUpdaterTests::createModelNodes()
+{
+    ModelTreeNode::ModelTreeNodePtr rootNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode);
+    ModelTreeNode::ModelTreeNodePtr projectNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode);
+    rootNode->addChild(projectNode);
+
+    Data::SourceLocation location = Data::SourceLocation(FILE_PATH, 0, 0);
+    ModelTreeNode::ModelTreeNodePtr fileNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode(FILE_PATH, location));
+    projectNode->addChild(fileNode);
+
+    location = Data::SourceLocation(FILE_PATH, 0, 0);
+    ModelTreeNode::ModelTreeNodePtr moduleNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Module1", location));
+
+    location = Data::SourceLocation(FILE_PATH, 2, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num1", location)));
+    location = Data::SourceLocation(FILE_PATH, 3, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num2", location)));
+    fileNode->addChild(moduleNode);
+
+    location = Data::SourceLocation(FILE_PATH, 0, 0);
+    moduleNode = ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Module2", location));
+
+    location = Data::SourceLocation(FILE_PATH, 6, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num3", location)));
+    location = Data::SourceLocation(FILE_PATH, 7, 3);
+    moduleNode->addChild(ModelTreeNode::ModelTreeNodePtr(new ModelTreeNode("Num4", location)));
+    fileNode->addChild(moduleNode);
+
+    return rootNode;
+}
+
+void StructuresViewIndexUpdaterTests::test_forceUpdate()
+{
+    QSignalSpy spy(m_indexUpdater, &OverviewIndexUpdater::currentIndexUpdated);
+    const int lineNumber = 6;
+
+    m_editorWidget->gotoLine(lineNumber);
+    m_indexUpdater->setEditor(m_editorWidget);
+    m_indexUpdater->updateCurrentIndex();
+
+    QCOMPARE(spy.count(), 1);
+
+    const QVariant result = spy.at(0).at(0);
+    QCOMPARE(result.type(), QVariant::ModelIndex);
+
+    const QModelIndex index = qvariant_cast<QModelIndex>(result);
+    QCOMPARE(index.isValid(), true);
+
+    const ModelTreeNode *symbol = static_cast<ModelTreeNode *>(index.internalPointer());
+    const Data::SourceLocation location = symbol->getSourceLocation();
+    QCOMPARE(location.path(), FILE_PATH);
+    QCOMPARE(location.line(), lineNumber);
+}

--- a/tests/structuresviewindexupdater_tests.h
+++ b/tests/structuresviewindexupdater_tests.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+#include "../overviewmodel.h"
+#include "../structuresviewindexupdater.h"
+
+#include "../modeltreenode.h"
+
+namespace Asn1Acn {
+namespace Internal {
+namespace Tests {
+
+class StructuresViewIndexUpdaterTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit StructuresViewIndexUpdaterTests(QObject *parent = 0);
+    ~StructuresViewIndexUpdaterTests();
+
+private slots:
+    void test_forceUpdate();
+
+private:
+    ModelTreeNode::ModelTreeNodePtr createModelNodes();
+    TextEditor::TextEditorWidget *createEditorWidget();
+
+    OverviewModel *m_model;
+    StructuresViewIndexUpdater *m_indexUpdater;
+    TextEditor::TextEditorWidget *m_editorWidget;
+};
+
+} // namespace Tests
+} // namespace Internal
+} // namespace Asn1Acn


### PR DESCRIPTION
The test were created alongside with the feature. There are tests for both classes introduced. One of the class inherits from the other, extending it a little. I had some doubts while creating tests, among which was: if there should be one or two test classes. I've decided that two are better in terms it clearly shows what is tested in which class. A lot of code in both test classes is similar, so it was natural temptation to store it in one base class (which would mimic the structure of classes being tested), but I rejected the idea, as this would make test code as complex as classes tested. Another thing was to decide if tests of StructuresViewIndexUpdater should cover all cases, including the ones being covered by the base class tests - I decided no, and made it test only the funciton specified in this class.