### PR TITLE
Travis will allow failures on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     compiler: gcc
   - os: linux
     compiler: clang
+  allow_failures:
+  - os: osx
+  fast_finish: true
 
 dist: trusty
 sudo: required


### PR DESCRIPTION
It's a temporary solution because our builds have to wait for a very
long time to get available OSX machine.

Better solution requires changes on Travis side - either more OSX
machines or possibility to skip osx builds and run them only from cron
(for example).

-------------------------

mail about passing is sent when all "required" jobs finish, so probably no mail is sent when "allowed failures" fails. So they will require some manual inspection from time to time (probably on master only)
If @psockoN7 you're ok with that - plz accept :)