### PR TITLE
Fixed clang build error and warning

### DIFF
--- a/structuresview.cpp
+++ b/structuresview.cpp
@@ -57,7 +57,7 @@ void StructuresViewWidget::modelUpdated()
 
 std::shared_ptr<OverviewIndexUpdater> StructuresViewWidget::createIndexUpdater() const
 {
-    auto indexUpdater = std::make_unique<StructuresViewIndexUpdater>(m_model);
+    auto indexUpdater = std::make_shared<StructuresViewIndexUpdater>(m_model);
 
     connect(indexUpdater.get(), &OverviewIndexUpdater::currentIndexUpdated,
             this, &StructuresViewWidget::updateSelectionInTree);

--- a/tests/structuresviewindexupdater_tests.cpp
+++ b/tests/structuresviewindexupdater_tests.cpp
@@ -36,7 +36,6 @@
 using namespace Asn1Acn::Internal;
 using namespace Asn1Acn::Internal::Tests;
 
-static const int RESPONSE_WAIT_TIME_MS = 600;
 static const QString FILE_PATH("/test/file1.asn");
 
 StructuresViewIndexUpdaterTests::StructuresViewIndexUpdaterTests(QObject *parent)


### PR DESCRIPTION
I've noticed that Clang build was failing, and this is the fix. 