### PR TITLE
Asnide 165 asnide 167 autocompletion fixes

### DIFF
--- a/completion/autocompleter.cpp
+++ b/completion/autocompleter.cpp
@@ -28,8 +28,6 @@
 
 #include <QTextCursor>
 
-#include <QDebug>
-
 using namespace Asn1Acn::Internal::Completion;
 
 bool AutoCompleter::isInComment(const QTextCursor &cursor) const
@@ -102,14 +100,19 @@ QString AutoCompleter::insertMatchingQuote(const QTextCursor &cursor,
                                            bool skipChars,
                                            int *skippedChars) const
 {
-    Q_UNUSED(cursor)
     const QChar quote(QLatin1Char('"'));
-    if (text.isEmpty() || text != quote)
+
+    if (text != quote)
         return QString();
+
     if (lookAhead == quote && skipChars) {
         ++*skippedChars;
         return QString();
     }
+
+    if (isInString(cursor))
+        return QString();
+
     return quote;
 }
 
@@ -128,7 +131,8 @@ bool AutoCompleter::contextAllowsAutoBrackets(const QTextCursor &cursor,
 
 bool AutoCompleter::contextAllowsAutoQuotes(const QTextCursor &cursor, const QString &textToInsert) const
 {
-    return contextAllowsAutoBrackets(cursor, textToInsert);
+    Q_UNUSED(textToInsert);
+    return !isInComment(cursor);
 }
 
 int AutoCompleter::paragraphSeparatorAboutToBeInserted(QTextCursor &cursor,

--- a/completion/autocompleter.cpp
+++ b/completion/autocompleter.cpp
@@ -34,12 +34,11 @@ bool AutoCompleter::isInComment(const QTextCursor &cursor) const
 {
     QTextCursor moved = cursor;
 
-    const int commentIdx = findCommentIndex(moved);
-    if (commentIdx == -1)
+    int idx = findWordIndexInCurrentLine(moved, QLatin1String("--"));
+    if (idx == -1)
         return false;
 
-    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::MoveAnchor);
-    moved.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, commentIdx);
+    moveCursorInCurrentLine(moved, idx);
 
     return !isInString(moved);
 }
@@ -147,14 +146,6 @@ int AutoCompleter::paragraphSeparatorAboutToBeInserted(QTextCursor &cursor,
     return TextEditor::AutoCompleter::paragraphSeparatorAboutToBeInserted(cursor, tabSettings);
 }
 
-int AutoCompleter::findCommentIndex(const QTextCursor &cursor) const
-{
-    QTextCursor moved = cursor;
-    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
-
-    return moved.selectedText().indexOf(QLatin1Literal("--"));
-}
-
 bool AutoCompleter::tryInsertEndKeyword(QTextCursor &cursor) const
 {
     if (!shouldInsertEndKeyword(cursor))
@@ -167,7 +158,7 @@ bool AutoCompleter::tryInsertEndKeyword(QTextCursor &cursor) const
 
 bool AutoCompleter::shouldInsertEndKeyword(QTextCursor &cursor) const
 {
-    return containsBeginKeyword(cursor) && beginKeywordMismatched(cursor);
+    return containsBeginKeyword(cursor) && contextAllowsEndKeyword(cursor) && beginKeywordMismatched(cursor);
 }
 
 bool AutoCompleter::containsBeginKeyword(QTextCursor &cursor) const
@@ -182,18 +173,35 @@ bool AutoCompleter::containsBeginKeyword(QTextCursor &cursor) const
     return words.last() == QLatin1String("BEGIN");
 }
 
+bool AutoCompleter::contextAllowsEndKeyword(const QTextCursor &cursor) const
+{
+    QTextCursor moved = cursor;
+
+    const int idx = findWordIndexInCurrentLine(moved, QLatin1String("BEGIN"));
+    if (idx == -1)
+        return false;
+
+    moveCursorInCurrentLine(moved, idx);
+
+    return !isInComment(moved) && !isInString(moved);
+}
+
 bool AutoCompleter::beginKeywordMismatched(QTextCursor &cursor) const
 {
     QTextCursor moved = cursor;
 
     while(moved.movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor)) {
-        if (moved.selectedText() == QLatin1String("END"))
+        QString text = moved.selectedText();
+        moved.clearSelection();
+
+        if (isInComment(moved) || isInString(moved))
+            continue;
+
+        if (text == QLatin1String("END"))
             return false;
 
-        if (moved.selectedText() == QLatin1String("BEGIN"))
+        if (text == QLatin1String("BEGIN"))
             return true;
-
-        moved.clearSelection();
     }
 
     return true;
@@ -206,4 +214,18 @@ void AutoCompleter::insertEndKeyword(QTextCursor &cursor) const
     cursor.insertBlock();
     cursor.insertText(QLatin1String("END"));
     cursor.setPosition(pos);
+}
+
+int AutoCompleter::findWordIndexInCurrentLine(const QTextCursor &cursor, const QLatin1String &word) const
+{
+    QTextCursor moved = cursor;
+    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+
+    return moved.selectedText().indexOf(word);
+}
+
+void AutoCompleter::moveCursorInCurrentLine(QTextCursor &cursor, const int position) const
+{
+    cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::MoveAnchor);
+    cursor.movePosition(QTextCursor::Right, QTextCursor::MoveAnchor, position);
 }

--- a/completion/autocompleter.cpp
+++ b/completion/autocompleter.cpp
@@ -28,14 +28,22 @@
 
 #include <QTextCursor>
 
+#include <QDebug>
+
 using namespace Asn1Acn::Internal::Completion;
 
 bool AutoCompleter::isInComment(const QTextCursor &cursor) const
 {
-    // TODO: This doesn't handle '--' inside quotes
     QTextCursor moved = cursor;
-    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
-    return moved.selectedText().contains(QLatin1Literal("--"));
+
+    const int commentIdx = findCommentIndex(moved);
+    if (commentIdx == -1)
+        return false;
+
+    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::MoveAnchor);
+    moved.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, commentIdx);
+
+    return !isInString(moved);
 }
 
 bool AutoCompleter::isInString(const QTextCursor &cursor) const
@@ -135,6 +143,13 @@ int AutoCompleter::paragraphSeparatorAboutToBeInserted(QTextCursor &cursor,
     return TextEditor::AutoCompleter::paragraphSeparatorAboutToBeInserted(cursor, tabSettings);
 }
 
+int AutoCompleter::findCommentIndex(const QTextCursor &cursor) const
+{
+    QTextCursor moved = cursor;
+    moved.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+
+    return moved.selectedText().indexOf(QLatin1Literal("--"));
+}
 
 bool AutoCompleter::tryInsertEndKeyword(QTextCursor &cursor) const
 {

--- a/completion/autocompleter.h
+++ b/completion/autocompleter.h
@@ -57,9 +57,12 @@ private:
     bool tryInsertEndKeyword(QTextCursor &cursor) const;
     bool shouldInsertEndKeyword(QTextCursor &cursor) const;
     bool containsBeginKeyword(QTextCursor &cursor) const;
+    bool contextAllowsEndKeyword(const QTextCursor &cursor) const;
     bool beginKeywordMismatched(QTextCursor &cursor) const;
     void insertEndKeyword(QTextCursor &cursor) const;
-    int findCommentIndex(const QTextCursor &cursor) const;
+
+    int findWordIndexInCurrentLine(const QTextCursor &cursor, const QLatin1String &word) const;
+    void moveCursorInCurrentLine(QTextCursor &cursor, const int position) const;
 };
 
 } /* nameapsce Completion */

--- a/completion/autocompleter.h
+++ b/completion/autocompleter.h
@@ -59,6 +59,7 @@ private:
     bool containsBeginKeyword(QTextCursor &cursor) const;
     bool beginKeywordMismatched(QTextCursor &cursor) const;
     void insertEndKeyword(QTextCursor &cursor) const;
+    int findCommentIndex(const QTextCursor &cursor) const;
 };
 
 } /* nameapsce Completion */

--- a/tests/autocompleter_tests.h
+++ b/tests/autocompleter_tests.h
@@ -43,10 +43,13 @@ public:
 private slots:
     void test_cursorInComment();
     void test_cursorNotInComment();
-    void test_cursorInEscapedString();
 
     void test_cursorInString();
     void test_cursorNotInString();
+    void test_cursorInEscapedString();
+
+    void test_cursorInCommentInString();
+    void test_cursorNotInCommentInString();
 
     void test_insertMatchingBraceEmptyString();
     void test_insertMatchingBraceForLeftBrace();
@@ -57,8 +60,16 @@ private slots:
     void test_insertMatchingQuoteForText();
     void test_insertMatchingQuoteForSkippedQuote();
     void test_insertMatchingQuoteForQuote();
+    void test_insertQuoteInsideMatchedQuotes();
 
     void test_insertParagraphSepareator();
+
+    void test_insertEndForBegin();
+    void test_insertEndForBeginAlreadyPaired();
+    void test_insertEndForCommentedBegin();
+    void test_insertEndForBeginInString();
+    void test_insertEndForBeginNotInTheEndOfLine();
+    void test_insertEndForBeginWhenEndIsCommented();
 
 private:
     Completion::AutoCompleter *m_completer;


### PR DESCRIPTION
Changes introduced: 
    - Handled comment inside quotes (comment inside quotes will not be treated as comment any more)
    - Changed adding double quotes logic to make more sense
    - Handled situation in which BEGIN / END keyword is in either commented or in string
    - Added more tests