### PR TITLE
ASNIDE-169 Added text cursor synchronization toggle button

### DIFF
--- a/tree-views/typestreewidget.h
+++ b/tree-views/typestreewidget.h
@@ -24,6 +24,8 @@
 ****************************************************************************/
 #pragma once
 
+#include <QToolButton>
+
 #include <coreplugin/inavigationwidgetfactory.h>
 
 #include "treeviewwidget.h"
@@ -38,6 +40,17 @@ class TypesTreeWidget : public TreeViewWidget
 public:
     TypesTreeWidget(Model *model, IndexUpdater *updater);
     ~TypesTreeWidget() override;
+
+    QToolButton *toggleSyncButton();
+
+private slots:
+    void toggleCursorSynchronization();
+
+private:
+    QToolButton *createToggleSyncButton();
+
+    QToolButton *m_toggleSync;
+    bool m_syncWithEditor;
 };
 
 class TypesTreeWidgetFactory : public Core::INavigationWidgetFactory


### PR DESCRIPTION
I've analised if the widget could be created in similar way as outline widget, which could be beneficial, because outline has support for cursor synchronization created already. Outline is connected with editor being changed and when editor == null, than the widget is destroyed. Such behaviour is not wanted in terms of Types View, because the widget needs to be present even when editor is closed. Since that I've decided that it is better to add support in relevant place manually.