### PR TITLE
ASNIDE-175 Fixed crashes when working with splitted text editor

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -76,12 +76,14 @@ void EditorWidget::finalizeInitialization()
     // TODO ? setLanguageSettingsId(Constants::SettingsId);
 
     auto document = qobject_cast<Document *>(textDocument());
-
     connect(document, &Document::extraSelectionsUpdated,
-            [this](const QList<QTextEdit::ExtraSelection> &selections){
-        setExtraSelections(TextEditorWidget::CodeWarningsSelection, selections);
-    });
+            this, &EditorWidget::onExtraSelectionsUpdated);
 
     insertExtraToolBarWidget(TextEditorWidget::Left,
                              new TreeViews::OutlineCombo(m_editorOutline->model(), m_editorOutline->indexUpdater()));
+}
+
+void EditorWidget::onExtraSelectionsUpdated(const QList<QTextEdit::ExtraSelection> &selections)
+{
+    setExtraSelections(TextEditorWidget::CodeWarningsSelection, selections);
 }

--- a/editor.h
+++ b/editor.h
@@ -47,6 +47,9 @@ protected:
 
     EditorOutline *m_editorOutline;
     Utils::CommentDefinition m_commentDefinition;
+
+private slots:
+    void onExtraSelectionsUpdated(const QList<QTextEdit::ExtraSelection> &selections);
 };
 
 } // namespace Internal

--- a/tree-views/indexupdater.cpp
+++ b/tree-views/indexupdater.cpp
@@ -42,8 +42,7 @@ IndexUpdater::IndexUpdater(const Model *model, QObject *parent)
 
 void IndexUpdater::setEditor(TextEditor::TextEditorWidget *editorWidget)
 {
-    if (m_editorWidget != nullptr)
-        m_editorWidget->disconnect(m_updateIndexTimer);
+    unsetEditor();
 
     m_editorWidget = editorWidget;
 
@@ -54,6 +53,14 @@ void IndexUpdater::setEditor(TextEditor::TextEditorWidget *editorWidget)
     } else {
         emit currentIndexUpdated(QModelIndex());
     }
+}
+
+void IndexUpdater::unsetEditor()
+{
+    if (m_editorWidget != nullptr)
+        m_editorWidget->disconnect(m_updateIndexTimer);
+
+    m_editorWidget = nullptr;
 }
 
 void IndexUpdater::updateCurrentIndex()

--- a/tree-views/indexupdater.h
+++ b/tree-views/indexupdater.h
@@ -47,6 +47,8 @@ public:
     virtual ~IndexUpdater() = default;
 
     void setEditor(TextEditor::TextEditorWidget *editorWidget);
+    void unsetEditor();
+
     void updateCurrentIndex();
 
 signals:

--- a/tree-views/typestreeindexupdater.cpp
+++ b/tree-views/typestreeindexupdater.cpp
@@ -44,6 +44,9 @@ TypesTreeIndexUpdater::TypesTreeIndexUpdater(const Model *model, QObject *parent
 {
     connect(Core::EditorManager::instance(), &Core::EditorManager::currentEditorChanged,
             this, &TypesTreeIndexUpdater::onEditorChanged);
+
+    connect(Core::EditorManager::instance(), &Core::EditorManager::editorAboutToClose,
+            this, &TypesTreeIndexUpdater::onEditorAboutToClose);
 }
 
 QModelIndex TypesTreeIndexUpdater::currentRootIndex() const
@@ -61,7 +64,12 @@ QModelIndex TypesTreeIndexUpdater::currentRootIndex() const
 void TypesTreeIndexUpdater::onEditorChanged(Core::IEditor *editor)
 {
     Q_UNUSED(editor);
-
     TextEditor::TextEditorWidget *editorWidget = TextEditor::TextEditorWidget::currentTextEditorWidget();
     setEditor(editorWidget);
+}
+
+void TypesTreeIndexUpdater::onEditorAboutToClose(Core::IEditor *editor)
+{
+    Q_UNUSED(editor);
+    unsetEditor();
 }

--- a/tree-views/typestreeindexupdater.h
+++ b/tree-views/typestreeindexupdater.h
@@ -36,8 +36,9 @@ class TypesTreeIndexUpdater : public IndexUpdater
 public:
     explicit TypesTreeIndexUpdater(const Model *model, QObject *parent);
 
-public slots:
+private slots:
     void onEditorChanged(Core::IEditor *editor);
+    void onEditorAboutToClose(Core::IEditor *editor);
 
 protected:
     QModelIndex currentRootIndex() const override;


### PR DESCRIPTION
There were two different crashes while working with splitted editor.  One was common "read after free" issue. The other one came from connecting signal to lambda expression. Similar construction is still used, which should be kept for further dicussion. 