### PR TITLE
ASNIDE-174 Fixed compile error highlight when opening and closing err…

### DIFF
--- a/data/file.cpp
+++ b/data/file.cpp
@@ -60,7 +60,17 @@ void File::addTypeReference(std::unique_ptr<TypeReference> ref)
     m_typeReferences.insert(std::make_pair(ref->location().line(), std::move(ref)));
 }
 
+void File::addErrorMessage(const ErrorMessage &message)
+{
+    m_errorList.push_back(message);
+}
+
 void File::clearReferences()
 {
     m_typeReferences.clear();
+}
+
+void File::clearErrors()
+{
+    m_errorList.clear();
 }

--- a/data/file.h
+++ b/data/file.h
@@ -31,6 +31,7 @@
 #include "definitions.h"
 #include "node.h"
 #include "typereference.h"
+#include "errormessage.h"
 
 namespace Asn1Acn {
 namespace Internal {
@@ -46,19 +47,25 @@ public:
 
     void add(std::unique_ptr<Definitions> defs);
     void addTypeReference(std::unique_ptr<TypeReference> ref);
+    void addErrorMessage(const ErrorMessage &message);
 
     using DefinitionsList = std::vector<std::unique_ptr<Definitions>>;
     using ReferencesMap = std::multimap<int, std::unique_ptr<TypeReference>>;
+    using ErrorList = std::vector<ErrorMessage>;
 
     const DefinitionsList &definitionsList() const { return m_definitionsList; }
     const Definitions *definitions(const QString &name) const;
 
     const ReferencesMap &references() const { return m_typeReferences; }
+    const ErrorList &errors() const { return m_errorList; }
+
     void clearReferences();
+    void clearErrors();
 
 private:
     DefinitionsList m_definitionsList;
     ReferencesMap m_typeReferences;
+    ErrorList m_errorList;
 
     std::map<QString, Definitions *> m_definitionsByNameMap;
 };

--- a/document.h
+++ b/document.h
@@ -44,11 +44,17 @@ public:
     void scheduleProcessDocument();
 
 signals:
-    void extraSelectionsUpdated(const QList<QTextEdit::ExtraSelection> &selections);
+    void extraSelectionsUpdated(const QList<QTextEdit::ExtraSelection> &selections) const;
+
+private slots:
+    void onModelChanged();
 
 private:
     void onFilePathChanged(const Utils::FileName &oldPath, const Utils::FileName &newPath);
     void processDocument();
+
+    void updateExtraSelections() const;
+    const QString activeProjectName() const;
 
     QTimer m_processorTimer;
 };

--- a/projectcontenthandler.h
+++ b/projectcontenthandler.h
@@ -60,9 +60,6 @@ public:
     void handleFileListChanged(const QString &projectName, const QStringList &fileList);
     void handleFileContentChanged(const QString &path);
 
-signals:
-    void codeErrorsChanged(const std::vector<Data::ErrorMessage> &errorMessages);
-
 private slots:
     void onFilesProcessingFinished(const QString &projectName);
 
@@ -77,8 +74,14 @@ private:
     void startProcessing(DocumentProcessor *dp);
     void allProcessingFinished();
 
-    void handleFilesProcesedWithSuccess(const QString &projectName, std::vector<std::unique_ptr<Data::File>> parsedDocuments);
-    void handleFilesProcesedWithFailure(const QString &projectName, std::vector<std::unique_ptr<Data::File>> parsedDocuments);
+    void handleFilesProcesedWithSuccess(const QString &projectName,
+                                        std::vector<std::unique_ptr<Data::File>> parsedDocuments);
+
+    void handleFilesProcesedWithFailure(const QString &projectName,
+                                        std::vector<std::unique_ptr<Data::File>> parsedDocuments,
+                                        const std::vector<Data::ErrorMessage> &errorMessages);
+
+    void refreshErrorMessages(Data::File *file, const std::vector<Data::ErrorMessage> &errorMessages);
 
     ParsedDataStorage *m_storage;
     ModelValidityGuard *m_guard;


### PR DESCRIPTION
…ored file

The issue in error highlighting was that it was connected with proccess of building project by deamon, and after building the information is lost. Changes were made to store error information within Data::File class objects, so information about errors is updated for every file after each build. 