### PR TITLE
Asnide 220 fix crash when creating link

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -338,6 +338,7 @@ SOURCES += \
     tests/autocompleter_tests.cpp \
     tests/sourcemapper_tests.cpp \
     tests/modelvalidityguard_tests.cpp \
+    tests/linkcreator_tests.cpp \
     \
     tests/networkreply.cpp \
     tests/parsingserviceproviderstub.cpp \
@@ -367,6 +368,7 @@ HEADERS += \
     tests/autocompleter_tests.h \
     tests/sourcemapper_tests.h \
     tests/modelvalidityguard_tests.h \
+    tests/linkcreator_tests.h \
     \
     tests/networkreply.h \
     tests/parsingserviceproviderstub.h \

--- a/src/asn1acn.cpp
+++ b/src/asn1acn.cpp
@@ -77,6 +77,7 @@
 #include "tests/sourcemapper_tests.h"
 #include "tests/modelvalidityguard_tests.h"
 #include "libraries/tests/librarymodel_tests.h"
+#include "tests/linkcreator_tests.h"
 #include "libraries/tests/modulemetadataparser_tests.h"
 #include "libraries/tests/generalmetadataparser_tests.h"
 #include "tree-views/tests/displayrolevisitor_tests.h"
@@ -261,6 +262,7 @@ QList<QObject *> Asn1AcnPlugin::createTestObjects() const
             << new Tests::AutoCompleterTests
             << new Tests::SourceMapperTests
             << new Tests::ModelValidityGuardTests
+            << new Tests::LinkCreatorTests
                ;
 }
 #endif

--- a/src/asneditor.cpp
+++ b/src/asneditor.cpp
@@ -82,7 +82,7 @@ AsnEditorWidget::Link AsnEditorWidget::findLinkAt(const QTextCursor &cursor,
 {
     Q_UNUSED(inNextSplit);
 
-    LinkCreator linkCreator(*textDocument());
+    LinkCreator linkCreator(*textDocument(), ParsedDataStorage::instance());
     if (resolveTarget)
         return linkCreator.createTargetLink(cursor);
     else

--- a/src/linkcreator.cpp
+++ b/src/linkcreator.cpp
@@ -62,13 +62,14 @@ Data::TypeReference LinkCreator::getSymbolTypeReference(const QTextCursor &curso
 
     const auto file = m_storage->getAnyFileForPath(m_documentPath);
 
-    return file != nullptr
-            ? getTypeReference(file, cursor.blockNumber() + 1, cursor.columnNumber())
-            : Data::TypeReference();
+    return getTypeReference(file, cursor.blockNumber() + 1, cursor.columnNumber());
 }
 
 Data::TypeReference LinkCreator::getTypeReference(const Data::File *file, int line, int col) const
 {
+    if (file == nullptr)
+        return Data::TypeReference();
+
     const auto range = file->references().equal_range(line);
     for(auto it = range.first; it != range.second; it++) {
         const int referedColumn = it->second->location().column();

--- a/src/linkcreator.cpp
+++ b/src/linkcreator.cpp
@@ -62,7 +62,9 @@ Data::TypeReference LinkCreator::getSymbolTypeReference(const QTextCursor &curso
 
     const auto file = ParsedDataStorage::instance()->getAnyFileForPath(m_documentPath);
 
-    return getTypeReference(file, cursor.blockNumber() + 1, cursor.columnNumber());
+    return file != nullptr
+            ? getTypeReference(file, cursor.blockNumber() + 1, cursor.columnNumber())
+            : Data::TypeReference();
 }
 
 Data::TypeReference LinkCreator::getTypeReference(const Data::File *file, int line, int col) const

--- a/src/linkcreator.h
+++ b/src/linkcreator.h
@@ -36,6 +36,8 @@
 #include "data/typereference.h"
 #include "data/sourcelocation.h"
 
+#include "parseddatastorage.h"
+
 namespace Asn1Acn {
 namespace Internal {
 
@@ -45,7 +47,7 @@ public:
 
     using Link = TextEditor::TextEditorWidget::Link;
 
-    LinkCreator(const TextEditor::TextDocument &document);
+    LinkCreator(const TextEditor::TextDocument &document, const ParsedDataStorage *storage);
 
     Link createHighlightLink(const QTextCursor &cursor) const;
     Link createTargetLink(const QTextCursor &cursor) const;
@@ -65,6 +67,7 @@ private:
 
     const QString m_documentPath;
     const TextEditor::TextDocument &m_textDocument;
+    const ParsedDataStorage *m_storage;
 };
 
 } /* namespace Internal */

--- a/src/tests/linkcreator_tests.cpp
+++ b/src/tests/linkcreator_tests.cpp
@@ -1,0 +1,158 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "linkcreator_tests.h"
+
+#include <QtTest>
+
+#include <QTextCursor>
+
+#include <utils/fileutils.h>
+#include <texteditor/textdocument.h>
+
+#include <data/file.h>
+#include <data/typereference.h>
+#include <data/types/builtintypes.h>
+
+#include <linkcreator.h>
+#include <parseddatastorage.h>
+
+using namespace Asn1Acn::Internal;
+using namespace Asn1Acn::Internal::Tests;
+
+LinkCreatorTests::LinkCreatorTests(QObject *parent)
+    : QObject(parent)
+    , m_storage(std::make_unique<ParsedDataStorage>())
+    , m_path("/path/to/file/file.asn")
+    , m_project("project_name")
+{
+    m_storage->addProject(m_project);
+}
+
+namespace {
+std::unique_ptr<TextEditor::TextDocument> createDocument(const QString &path, const QByteArray &content)
+{
+    auto doc = std::make_unique<TextEditor::TextDocument>();
+    doc->setFilePath(Utils::FileName::fromString(path));
+    doc->setContents(content);
+
+    return std::move(doc);
+}
+} // namespace anonymous
+
+void LinkCreatorTests::test_createLinksInEmptyDocument()
+{
+    auto doc = createDocument(m_path, "          ");
+
+    QTextCursor cursor(doc->document());
+    cursor.setPosition(5);
+
+    LinkCreator linkCreator(*doc, m_storage.get());
+
+    const auto highlightLink = linkCreator.createHighlightLink(cursor);
+    QVERIFY(!highlightLink.hasValidLinkText());
+    QVERIFY(highlightLink.hasValidTarget());
+    QCOMPARE(highlightLink.targetFileName, m_path);
+
+    const auto targetLink = linkCreator.createTargetLink(cursor);
+    QVERIFY(!targetLink.hasValidLinkText());
+    QVERIFY(!targetLink.hasValidTarget());
+    QCOMPARE(targetLink.targetFileName, QString());
+}
+
+void LinkCreatorTests::test_createLinksFromEmptyStorage()
+{
+    auto doc = createDocument(m_path, "TAILORED-PUS-C DEFINITIONS AUTOMATIC TAGS ::= BEGIN \nEND");
+
+    QTextCursor cursor(doc->document());
+    cursor.setPosition(13);
+
+    LinkCreator linkCreator(*doc, m_storage.get());
+
+    const auto highlightLink = linkCreator.createHighlightLink(cursor);
+    QVERIFY(!highlightLink.hasValidLinkText());
+    QVERIFY(highlightLink.hasValidTarget());
+    QCOMPARE(highlightLink.targetFileName, m_path);
+
+    const auto targetLink = linkCreator.createTargetLink(cursor);
+    QVERIFY(!targetLink.hasValidLinkText());
+    QVERIFY(!targetLink.hasValidTarget());
+    QCOMPARE(targetLink.targetFileName, QString());
+}
+
+void LinkCreatorTests::test_createHighlight()
+{
+    auto file = std::make_unique<Data::File>(m_path);
+    auto ref = std::make_unique<Data::TypeReference>("TypeName", "ModuleName", Data::SourceLocation(m_path, 1, 5));
+
+    file->addTypeReference(std::move(ref));
+
+    m_storage->addFileToProject(m_project, std::move(file));
+
+    auto doc = createDocument(m_path, "TAILORED-PUS-C DEFINITIONS AUTOMATIC TAGS ::= BEGIN \nEND");
+    QTextCursor cursor(doc->document());
+    cursor.setPosition(10);
+
+    LinkCreator linkCreator(*doc, m_storage.get());
+    const auto link = linkCreator.createHighlightLink(cursor);
+
+    QVERIFY(link.hasValidLinkText());
+    QCOMPARE(link.linkTextStart, 5);
+    QCOMPARE(link.linkTextEnd, 13);
+    QCOMPARE(link.targetFileName, m_path);
+
+    m_storage->removeFileFromProject(m_project, m_path);
+}
+
+void LinkCreatorTests::test_createTarget()
+{
+    auto file = std::make_unique<Data::File>(m_path);
+    auto ref = std::make_unique<Data::TypeReference>("TypeName", "ModuleName", Data::SourceLocation(m_path, 1, 5));
+
+    file->addTypeReference(std::move(ref));
+
+    auto typeAssignment = std::make_unique<Data::TypeAssignment>("TypeName",
+                                                                 Data::SourceLocation(m_path, 1, 15),
+                                                                 Data::Types::BuiltinType::createBuiltinType("IntegerType"));
+    auto defs = std::make_unique<Data::Definitions>("ModuleName", Data::SourceLocation(m_path, 0, 0));
+
+    defs->addType(std::move(typeAssignment));
+    file->add(std::move(defs));
+    m_storage->addFileToProject(m_project, std::move(file));
+
+    auto doc = createDocument(m_path, "TAILORED-PUS-C DEFINITIONS AUTOMATIC TAGS ::= BEGIN \nEND");
+    QTextCursor cursor(doc->document());
+    cursor.setPosition(10);
+
+    LinkCreator linkCreator(*doc, m_storage.get());
+    const auto link = linkCreator.createTargetLink(cursor);
+
+    QVERIFY(link.hasValidTarget());
+    QCOMPARE(link.targetColumn, 15);
+    QCOMPARE(link.targetLine, 1);
+    QCOMPARE(link.targetFileName, m_path);
+
+    m_storage->removeFileFromProject(m_project, m_path);
+}

--- a/src/tests/linkcreator_tests.h
+++ b/src/tests/linkcreator_tests.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 N7 Mobile sp. z o. o.
+** Contact: http://n7mobile.pl/Space
+**
+** This file is part of ASN.1/ACN Plugin for QtCreator.
+**
+** Plugin was developed under a programme and funded by
+** European Space Agency.
+**
+** This Plugin is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#pragma once
+
+#include <memory>
+
+#include <QObject>
+
+#include <linkcreator.h>
+#include <parseddatastorage.h>
+
+namespace Asn1Acn {
+namespace Internal {
+namespace Tests {
+
+class LinkCreatorTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit LinkCreatorTests(QObject *parent = 0);
+
+private slots:
+    void test_createLinksInEmptyDocument();
+    void test_createLinksFromEmptyStorage();
+
+    void test_createHighlight();
+    void test_createTarget();
+
+private:
+    std::unique_ptr<ParsedDataStorage> m_storage;
+    const QString m_path;
+    const QString m_project;
+};
+
+} // namespace Tests
+} // namespace Internal
+} // namespace Asn1Acn


### PR DESCRIPTION
Fixed crash (nullptr dereference), and added tests to prove crash does not occur any more. 