### PR TITLE
ASNIDE-209 Implemented choice children parsing. Added related unit test.

### DIFF
--- a/src/astxmlparser.cpp
+++ b/src/astxmlparser.cpp
@@ -255,6 +255,8 @@ std::unique_ptr<Data::Types::Type> AstXmlParser::readType()
             readSequence();
         else if (name == QStringLiteral("SequenceOfType"))
             readSequenceOf();
+        else if (name == QStringLiteral("ChoiceType"))
+            readChoice();
         else
             m_xmlReader.skipCurrentElement();
     }
@@ -286,4 +288,10 @@ void AstXmlParser::readSequence()
 void AstXmlParser::readSequenceOf()
 {
     readType();
+}
+
+void AstXmlParser::readChoice()
+{
+    while(nextRequiredElementIs(QStringLiteral("ChoiceChild")))
+        readType();
 }

--- a/src/astxmlparser.h
+++ b/src/astxmlparser.h
@@ -79,6 +79,7 @@ private:
     std::unique_ptr<Data::Types::Type> readUserDefinedTypeReference(const Data::SourceLocation &location);
     void readSequence();
     void readSequenceOf();
+    void readChoice();
 
     QString readReferencedTypeNameAttribute();
     QString readReferencedModuleAttribute();

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -353,6 +353,55 @@ void AstXmlParserTests::test_sequenceTypeAssingment()
     QCOMPARE(ref->second->module(), QStringLiteral("ApplicationProcess"));
 }
 
+void AstXmlParserTests::test_choiceTypeAssignment()
+{
+    parse(R"(<?xml version="1.0" encoding="utf-8"?>)"
+          R"(<ASN1AST>)"
+          R"(  <Asn1File FileName="Test2File.asn">)"
+          R"(    <Asn1Module ID="TestDefinitions">)"
+          R"(      <TypeAssignments>)"
+          R"(        <TypeAssignment Name="FirstChoice" Line="4" CharPositionInLine="0">)"
+          R"(          <Type Line="4" CharPositionInLine="16">)"
+          R"(            <ChoiceType>)"
+          R"(              <ChoiceChild VarName="child-1" Line="6" CharPositionInLine="4" EnumID ="child_1_PRESENT">)"
+          R"(                <Type Line="6" CharPositionInLine="12">)"
+          R"(                  <ReferenceType ReferencedTypeName="MyInt" Min="MIN" Max="MAX" ReferencedModName="Exporter"/>)"
+          R"(                </Type>)"
+          R"(              </ChoiceChild>)"
+          R"(              <ChoiceChild VarName="child-2" Line="7" CharPositionInLine="4" EnumID ="child_2_PRESENT">)"
+          R"(                <Type Line="7" CharPositionInLine="12">)"
+          R"(                  <IntegerType Min="MIN" Max="MAX"/>)"
+          R"(                </Type>)"
+          R"(              </ChoiceChild>)"
+          R"(            </ChoiceType>)"
+          R"(          </Type>)"
+          R"(        </TypeAssignment>)"
+          R"(      </TypeAssignments>)"
+          R"(    </Asn1Module>)"
+          R"(  </Asn1File>)"
+          R"(</ASN1AST>)");
+
+    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("FirstChoice")->type()->name(), QStringLiteral("CHOICE"));
+
+    QVERIFY(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("FirstChoice")->location().isValid());
+
+    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("FirstChoice")->location().line(), 4);
+    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("FirstChoice")->location().column(), 0);
+    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("FirstChoice")->location().path(),
+            QLatin1String("Test2File.asn"));
+
+    QCOMPARE(static_cast<int>(m_parsedData["Test2File.asn"]->references().size()), 1);
+
+    const auto ref = m_parsedData["Test2File.asn"]->references().find(6);
+    QVERIFY(ref->second != nullptr);
+
+    QCOMPARE(ref->second->location().line(), 6);
+    QCOMPARE(ref->second->location().column(), 12);
+
+    QCOMPARE(ref->second->name(), QStringLiteral("MyInt"));
+    QCOMPARE(ref->second->module(), QStringLiteral("Exporter"));
+}
+
 void AstXmlParserTests::test_sequenceOfTypeAssingment()
 {
     parse(R"(<?xml version="1.0" encoding="utf-8"?>)"

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -55,6 +55,7 @@ private slots:
     void test_pathMapping();
     void test_sequenceTypeAssingment();
     void test_sequenceOfTypeAssingment();
+    void test_choiceTypeAssignment();
     void test_variableAssignment();
     void test_importedVariable();
     void test_multipleImportedVariable();


### PR DESCRIPTION
The only practical difference between CHOICE and SEQUENCE in AST is in data provided by children:

Choice contains `EnumID` field
`<ChoiceChild VarName="choiceChild-1" Line="12" CharPositionInLine="4" EnumID ="choiceChild_1_PRESENT">`

while sequence contains `Optional` field
`<SequenceOrSetChild VarName="nestetSequenceChild-2" Optional="False" Line="30" CharPositionInLine="8">`

