### PR TITLE
ASNIDE-243 Lib Module Schema updated - required/conflict fields merged with "imports"

### DIFF
--- a/schemas/asn1-lib-module-schema.json
+++ b/schemas/asn1-lib-module-schema.json
@@ -7,29 +7,28 @@
       "type": "string",
       "minLength": 1
     },
-    "asn1TypeName": {
-      "type": "string",
-      "pattern": "^[A-Z]([a-zA-Z0-9]|-)*$"
-    },
-    "referenceList": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/nonEmptyString" }
-    },
     "fileList": {
       "type": "array",
       "items": { "$ref": "#/definitions/nonEmptyString" }
     },
-    "importedType": {
+    "externalReference": {
       "type": "object",
       "properties": {
-        "from": { "$ref": "#/definitions/asn1TypeName" },
-        "types": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/asn1TypeName" }
-        }
+        "module": { "$ref": "#/definitions/nonEmptyString" },
+        "submodule": { "$ref": "#/definitions/nonEmptyString" },
+        "element": { "$ref": "#/definitions/nonEmptyString" }
       },
-      "required": ["from", "types"],
+      "required": ["submodule", "element"],
       "additionalProperties": false
+    },
+    "referenceList": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/nonEmptyString" },
+          { "$ref": "#/definitions/externalReference" }
+        ]
+      }
     }
   },
   "type": "object",
@@ -54,11 +53,7 @@
                 "description": { "type": "string" },
                 "asn1Files": { "$ref": "#/definitions/fileList" },
                 "conflicts": { "$ref": "#/definitions/referenceList" },
-                "requires": { "$ref": "#/definitions/referenceList" },
-                "imports": {
-                  "type": "array",
-                  "items": { "$ref": "#/definitions/importedType" }
-                }
+                "requires": { "$ref": "#/definitions/referenceList" }
               },
               "required": [
                 "name"


### PR DESCRIPTION
```
 "requires": ["local-reference", 
                   {"module": "dsdads", 
                    "submodule": "dsadasd", 
                    "element":"xxsax"} ]
```
"module" is optional, 
"conflicts" accepts same types,
"imports" are removed