### PR TITLE
ASNIDE-230 Implemented copying files imported to project

### DIFF
--- a/asn1acn.pro
+++ b/asn1acn.pro
@@ -130,6 +130,7 @@ SOURCES += \
     libraries/componentimporter.cpp \
     libraries/componentdirectorywatcher.cpp \
     libraries/componentlibraryprocessor.cpp \
+    libraries/generalmetadataprocessor.cpp \
     libraries/componentlibrarydispatcher.cpp \
     libraries/librarystorage.cpp \
     libraries/metadatamodel.cpp \
@@ -255,6 +256,7 @@ HEADERS += \
     libraries/componentimporter.h \
     libraries/componentdirectorywatcher.h \
     libraries/componentlibraryprocessor.h \
+    libraries/generalmetadataprocessor.h \
     libraries/componentlibrarydispatcher.h \
     libraries/librarystorage.h \
     libraries/metadatamodel.h \

--- a/src/filesourcereader.cpp
+++ b/src/filesourcereader.cpp
@@ -48,6 +48,9 @@ QString FileSourceReader::readContent(const QString &fileName) const
 
 QString FileSourceReader::readFromFile(const QString &fileName) const
 {
+    if (fileName.isEmpty())
+        return QString();
+
     QFile file(fileName);
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))

--- a/src/libraries/componentdirectorywatcher.cpp
+++ b/src/libraries/componentdirectorywatcher.cpp
@@ -92,9 +92,12 @@ void ComponentDirectoryWatcher::addMainDirectory(const QString &path)
 
     m_fsWatcher->addPath(path);
 
+    if (dir.exists(QStringLiteral("info.json")))
+        m_fsWatcher->addPath(dir.filePath(QStringLiteral("info.json")));
+
     const auto subDirectories = dir.entryList(QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot);
     for (const auto &subPath : subDirectories)
-        addSubDirectory(path + QString("/") + subPath);
+        addSubDirectory(dir.filePath(subPath));
 }
 
 
@@ -107,7 +110,7 @@ void ComponentDirectoryWatcher::addSubDirectory(const QString &path)
     m_fsWatcher->addPath(path);
 
     if (dir.exists(QStringLiteral("meta.json")))
-        m_fsWatcher->addPath(path + QStringLiteral("/meta.json"));
+        m_fsWatcher->addPath(dir.filePath(QStringLiteral("meta.json")));
 }
 
 void ComponentDirectoryWatcher::removeAll()
@@ -120,5 +123,8 @@ void ComponentDirectoryWatcher::removeAll()
     if (!files.empty())
         m_fsWatcher->removePaths(files);
 
-    LibraryStorage::instance()->removeLibraries();
+    auto storage = LibraryStorage::instance();
+
+    storage->removeLibraries();
+    storage->removeAllMetadata();
 }

--- a/src/libraries/componentimporter.cpp
+++ b/src/libraries/componentimporter.cpp
@@ -25,60 +25,78 @@
 
 #include "componentimporter.h"
 
-#include <QDir>
+#include <QFile>
 
 #include <projectexplorer/session.h>
 #include <projectexplorer/project.h>
 #include <projectexplorer/projectnodes.h>
 
-#include <utils/qtcassert.h>
-
 using namespace Asn1Acn::Internal::Libraries;
 
 void ComponentImporter::setFiles(const QStringList &files)
 {
-    m_files = files;
-}
-
-void ComponentImporter::setDirectories(const QStringList &paths)
-{
-    m_files = pathsInDirectory(paths);
+    m_sourceFiles = files;
 }
 
 const QStringList &ComponentImporter::files() const
 {
-    return m_files;
+    return m_sourceFiles;
 }
 
-void ComponentImporter::import() const
+void ComponentImporter::setDirectory(const QString &path)
 {
-    addPathsToProject(m_files);
+    m_sourceDir = QDir(path);
 }
 
-QStringList ComponentImporter::pathsInDirectory(const QStringList &directories)
-{
-    QStringList files;
-    QStringList filters;
-    filters << "*.asn" << "*.asn1" << "*.acn";
-
-    for(const auto &directory : directories) {
-        QDir dir(directory);
-        if (!dir.exists())
-            continue;
-
-        dir.setNameFilters(filters);
-        for (const auto &path : dir.entryList())
-            files << dir.filePath(path);
-    }
-
-    return files;
-}
-
-void ComponentImporter::addPathsToProject(const QStringList &paths) const
+void ComponentImporter::import()
 {
     const auto project = ProjectExplorer::SessionManager::startupProject();
-    if (project == nullptr)
-        return;
 
-    project->rootProjectNode()->addFiles(paths);
+    m_projectDir = QDir(project->projectDirectory().toString());
+    m_targetDir = QDir(m_projectDir.filePath(m_sourceDir.dirName()));
+
+    m_projectDir.mkpath(m_sourceDir.dirName());
+
+    const auto copied = copyFilesToProject();
+    addFilesToProject(project, copied);
+}
+
+QStringList ComponentImporter::copyFilesToProject()
+{
+    QStringList copiedFiles;
+
+    for (const auto &file : m_sourceFiles) {
+        QString target = targetFileName(file);
+
+        m_targetDir.mkpath(QFileInfo(target).absolutePath());
+
+        QFile::copy(file, m_targetDir.filePath(target));
+        copiedFiles.append(m_projectDir.relativeFilePath(target));
+    }
+
+    return copiedFiles;
+}
+
+QString ComponentImporter::targetFileName(const QString &file)
+{
+    QString relativeSrcPath = m_sourceDir.relativeFilePath(file);
+    return m_targetDir.filePath(relativeSrcPath);
+}
+
+void ComponentImporter::addFilesToProject(const ProjectExplorer::Project *project, const QStringList &files)
+{
+    const auto uniqueFiles = createUniqueFilesList(project, files);
+    project->rootProjectNode()->addFiles(uniqueFiles);
+}
+
+QStringList ComponentImporter::createUniqueFilesList(const ProjectExplorer::Project *project, const QStringList &newFiles)
+{
+    QStringList uniqueFiles;
+    const auto projectFiles = project->files(ProjectExplorer::Project::SourceFiles);
+
+    for (const auto &file : newFiles)
+        if (!projectFiles.contains(m_projectDir.filePath(file)))
+            uniqueFiles.append(file);
+
+    return uniqueFiles;
 }

--- a/src/libraries/componentimporter.cpp
+++ b/src/libraries/componentimporter.cpp
@@ -70,11 +70,20 @@ QStringList ComponentImporter::copyFilesToProject()
 
         m_targetDir.mkpath(QFileInfo(target).absolutePath());
 
-        QFile::copy(file, m_targetDir.filePath(target));
+        copyFile(file, m_targetDir.filePath(target));
+
         copiedFiles.append(m_projectDir.relativeFilePath(target));
     }
 
     return copiedFiles;
+}
+
+void ComponentImporter::copyFile(const QString &source, const QString &target)
+{
+    if (QFile::exists(target))
+        QFile::remove(target);
+
+    QFile::copy(source, target);
 }
 
 QString ComponentImporter::targetFileName(const QString &file)

--- a/src/libraries/componentimporter.h
+++ b/src/libraries/componentimporter.h
@@ -27,6 +27,11 @@
 
 #include <QString>
 #include <QStringList>
+#include <QDir>
+
+namespace ProjectExplorer {
+class Project;
+}
 
 namespace Asn1Acn {
 namespace Internal {
@@ -35,19 +40,24 @@ namespace Libraries {
 class ComponentImporter
 {
 public:
-    void setDirectories(const QStringList &paths);
+    void setDirectory(const QString &path);
     void setFiles(const QStringList &files);
 
     const QStringList &files() const;
 
-    void import() const;
+    void import();
 
 private:
-    QStringList pathsInDirectory(const QStringList &directories);
-    void addPathsToProject(const QStringList &paths) const;
+    QStringList copyFilesToProject();
+    QString targetFileName(const QString &file);
+    void addFilesToProject(const ProjectExplorer::Project *project, const QStringList &files);
+    QStringList createUniqueFilesList(const ProjectExplorer::Project *project, const QStringList &newFiles);
 
-    QStringList m_directories;
-    QStringList m_files;
+    QStringList m_sourceFiles;
+
+    QDir m_sourceDir;
+    QDir m_targetDir;
+    QDir m_projectDir;
 };
 
 } // namespace Libraries

--- a/src/libraries/componentimporter.h
+++ b/src/libraries/componentimporter.h
@@ -51,6 +51,7 @@ private:
     QStringList copyFilesToProject();
     QString targetFileName(const QString &file);
     void addFilesToProject(const ProjectExplorer::Project *project, const QStringList &files);
+    void copyFile(const QString &source, const QString &target);
     QStringList createUniqueFilesList(const ProjectExplorer::Project *project, const QStringList &newFiles);
 
     QStringList m_sourceFiles;

--- a/src/libraries/componentimporter.h
+++ b/src/libraries/componentimporter.h
@@ -49,10 +49,12 @@ public:
 
 private:
     QStringList copyFilesToProject();
+    void createTargetDir(QDir &parent, const QString &path);
     QString targetFileName(const QString &file);
     void addFilesToProject(const ProjectExplorer::Project *project, const QStringList &files);
     void copyFile(const QString &source, const QString &target);
     QStringList createUniqueFilesList(const ProjectExplorer::Project *project, const QStringList &newFiles);
+    void raiseErrorWindow(const QString &message);
 
     QStringList m_sourceFiles;
 

--- a/src/libraries/generalmetadataprocessor.cpp
+++ b/src/libraries/generalmetadataprocessor.cpp
@@ -23,31 +23,29 @@
 **
 ****************************************************************************/
 
-#include "componentlibrarydispatcher.h"
-
-#include "componentlibraryprocessor.h"
 #include "generalmetadataprocessor.h"
 
-#include "filesourcereader.h"
+#include "librarystorage.h"
+#include "generalmetadataparser.h"
 
+using namespace Asn1Acn::Internal;
 using namespace Asn1Acn::Internal::Libraries;
 
-void CompontentLibraryDispatcher::dispatch(const QStringList &directories, const QStringList &files) const
+GeneralMetadataProcessor::GeneralMetadataProcessor(const QString &path,
+                                                   const QString &file,
+                                                   const FileSourceReader &reader,
+                                                   QObject *parent)
+    : QObject(parent)
+    , m_reader(reader)
+    , m_path(path)
+    , m_file(file)
 {
-    static const FileSourceReader reader;
+}
 
-    for (const auto &directory : directories) {
-        const auto filesInDirectory = files.filter(directory);
+void GeneralMetadataProcessor::process()
+{
+    GeneralMetadataParser parser(m_reader.readContent(m_file).toLatin1(), m_path);
+    LibraryStorage::instance()->addGeneralMetadata(parser.parse());
 
-        const auto infoFile = filesInDirectory.filter("info.json").join(" ");
-        const auto generalProcessor = new GeneralMetadataProcessor(directory, infoFile, reader);
-        generalProcessor->process();
-
-        const auto metaFiles = filesInDirectory.filter("meta.json");
-        if (metaFiles.empty())
-            continue;
-
-        const auto componentProcessor = new ComponentLibraryProcessor(directory, filesInDirectory.filter("meta.json"), reader);
-        componentProcessor->process();
-    }
+    this->deleteLater();
 }

--- a/src/libraries/generalmetadataprocessor.h
+++ b/src/libraries/generalmetadataprocessor.h
@@ -22,32 +22,35 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **
 ****************************************************************************/
+#pragma once
 
-#include "componentlibrarydispatcher.h"
+#include <QObject>
+#include <QString>
 
-#include "componentlibraryprocessor.h"
-#include "generalmetadataprocessor.h"
+#include <filesourcereader.h>
 
-#include "filesourcereader.h"
+namespace Asn1Acn {
+namespace Internal {
+namespace Libraries {
 
-using namespace Asn1Acn::Internal::Libraries;
-
-void CompontentLibraryDispatcher::dispatch(const QStringList &directories, const QStringList &files) const
+class GeneralMetadataProcessor : public QObject
 {
-    static const FileSourceReader reader;
+    Q_OBJECT
 
-    for (const auto &directory : directories) {
-        const auto filesInDirectory = files.filter(directory);
+public:
+    GeneralMetadataProcessor(const QString &path,
+                             const QString &file,
+                             const FileSourceReader &reader,
+                             QObject *parent = nullptr);
+    void process();
 
-        const auto infoFile = filesInDirectory.filter("info.json").join(" ");
-        const auto generalProcessor = new GeneralMetadataProcessor(directory, infoFile, reader);
-        generalProcessor->process();
+private:
+    const FileSourceReader m_reader;
 
-        const auto metaFiles = filesInDirectory.filter("meta.json");
-        if (metaFiles.empty())
-            continue;
+    const QString m_path;
+    const QString m_file;
+};
 
-        const auto componentProcessor = new ComponentLibraryProcessor(directory, filesInDirectory.filter("meta.json"), reader);
-        componentProcessor->process();
-    }
-}
+} // namespace Libraries
+} // namespace Internal
+} // namespace Asn1Acn

--- a/src/libraries/librarystorage.cpp
+++ b/src/libraries/librarystorage.cpp
@@ -46,6 +46,18 @@ void LibraryStorage::addLibrary(LibraryPtr library)
     emit changed();
 }
 
+void LibraryStorage::addGeneralMetadata(Metadata::General metadata)
+{
+    QMutexLocker lock(&m_libraryMutex);
+    m_generalMetadata[metadata.path()] = metadata;
+}
+
+Metadata::General LibraryStorage::generalMetadata(const QString &path)
+{
+    QMutexLocker lock(&m_libraryMutex);
+    return m_generalMetadata[path];
+}
+
 void LibraryStorage::removeLibraries()
 {
     QMutexLocker lock(&m_libraryMutex);
@@ -55,6 +67,12 @@ void LibraryStorage::removeLibraries()
     m_libraries.clear();
 
     emit changed();
+}
+
+void LibraryStorage::removeAllMetadata()
+{
+    QMutexLocker lock(&m_libraryMutex);
+    m_generalMetadata.clear();
 }
 
 const Metadata::Library *LibraryStorage::library(const QString &path) const

--- a/src/libraries/librarystorage.h
+++ b/src/libraries/librarystorage.h
@@ -32,6 +32,7 @@
 #include <QString>
 
 #include "metadata/library.h"
+#include "metadata/general.h"
 
 namespace Asn1Acn {
 namespace Internal {
@@ -52,6 +53,10 @@ public:
     void addLibrary(LibraryPtr library);
     void removeLibraries();
 
+    void addGeneralMetadata(Metadata::General metadata);
+    void removeAllMetadata();
+
+    Metadata::General generalMetadata(const QString &path);
     const Metadata::Library *library(const QString &path) const;
 
 signals:
@@ -60,6 +65,7 @@ signals:
 
 private:
     std::map<QString, LibraryPtr> m_libraries;
+    std::map<QString, Metadata::General> m_generalMetadata;
 
     mutable QMutex m_libraryMutex;
 };

--- a/src/libraries/metadata/general.h
+++ b/src/libraries/metadata/general.h
@@ -34,6 +34,7 @@ namespace Metadata {
 class General
 {
 public:
+    General() = default;
     General(const QString &name, const QString &path)
         : m_name(name)
         , m_path(path)

--- a/src/libraries/wizard/selectsourcepage.cpp
+++ b/src/libraries/wizard/selectsourcepage.cpp
@@ -30,6 +30,9 @@
 
 #include <coreplugin/icore.h>
 
+#include <libraries/librarystorage.h>
+#include <libraries/metadata/general.h>
+
 #include "importcomponentwizard.h"
 
 using namespace Asn1Acn::Internal;
@@ -56,14 +59,14 @@ SelectSourcePage::SelectSourcePage(ComponentImporter &importer, QWidget *parent)
     registerField("builtInRadio", m_ui.builtInRadio);
     registerField("customRadio", m_ui.customRadio);
 
-    registerField("builtInCombo", m_ui.builtInCombo, "currentText");
+    registerField("builtInCombo", m_ui.builtInCombo, "currentData");
     registerField("pathChoser", m_ui.asn1sccPathChooser, "path", "pathChanged");
 }
 
 bool SelectSourcePage::validatePage()
 {
     if (m_ui.builtInRadio->isChecked())
-        m_importer.setDirectory(m_ui.builtInCombo->currentText());
+        m_importer.setDirectory(m_ui.builtInCombo->currentData().toString());
     else if (m_ui.customRadio->isChecked())
         m_importer.setDirectory(m_ui.asn1sccPathChooser->path());
 
@@ -82,11 +85,10 @@ void SelectSourcePage::refreshPaths()
 
     m_ui.builtInCombo->clear();
 
-    const auto detectedPaths = m_libraries->detectedLibPaths();
-    const auto manualPaths = m_libraries->manualLibPaths();
-
-    m_ui.builtInCombo->addItems(detectedPaths);
-    m_ui.builtInCombo->addItems(manualPaths);
+    for (const auto &path : m_libraries->libPaths()) {
+        const auto metadata = LibraryStorage::instance()->generalMetadata(path);
+        m_ui.builtInCombo->addItem(metadata.name(), metadata.path());
+    }
 }
 
 void SelectSourcePage::builtInRadioToggled(bool checked)

--- a/src/libraries/wizard/selectsourcepage.cpp
+++ b/src/libraries/wizard/selectsourcepage.cpp
@@ -63,9 +63,9 @@ SelectSourcePage::SelectSourcePage(ComponentImporter &importer, QWidget *parent)
 bool SelectSourcePage::validatePage()
 {
     if (m_ui.builtInRadio->isChecked())
-        m_importer.setDirectories(QStringList(m_ui.builtInCombo->currentText()));
+        m_importer.setDirectory(m_ui.builtInCombo->currentText());
     else if (m_ui.customRadio->isChecked())
-        m_importer.setDirectories(QStringList(m_ui.asn1sccPathChooser->path()));
+        m_importer.setDirectory(m_ui.asn1sccPathChooser->path());
 
     return QWizardPage::validatePage();
 }

--- a/src/options-pages/librarieswidget.cpp
+++ b/src/options-pages/librarieswidget.cpp
@@ -36,6 +36,7 @@
 #include <utils/detailswidget.h>
 
 #include <libraries/metadata/general.h>
+#include <libraries/librarystorage.h>
 #include <libraries/generalmetadataparser.h>
 #include <tr.h>
 
@@ -52,20 +53,12 @@ enum class Columns {
 
 const int LibEntryItemType = QTreeWidgetItem::UserType + 1;
 
-Libraries::Metadata::General readInfo(const QString &path)
-{
-    QFile file{path + "/info.json"};
-    Libraries::GeneralMetadataParser parser(file.open(QIODevice::ReadOnly) ? file.readAll() : QByteArray(),
-                                            path); // TODO use some singleton storage in future
-    return parser.parse();
-}
-
 class LibEntryItem : public QTreeWidgetItem
 {
   public:
     LibEntryItem(QTreeWidgetItem *parent, const QString &path)
         : QTreeWidgetItem(parent, LibEntryItemType)
-        , m_info(readInfo(path))
+        , m_info(Libraries::LibraryStorage::instance()->generalMetadata(path))
     {
     }
 


### PR DESCRIPTION
- it is not possible to import file to project more than once via wizard. It means that file will neither be copied nor added to project file. This is inconsistent with general Qt Creator behavior, but I came to conclusion, that it would be wrong in our case, as different library component might be using the same files, and the fact is hidden from the user. 

- the directory structure of imported file location will be recreated starting from the directory chosen in path chooser widget. For example, if user selects "Import Custom Library" from path ```/home``` , and after that in tree view marks for importing file  ```/home/asnide/workspace/asnide/asn1-pusc-lib/service-01/ErrorCodes.asn1``` , than the file will be copied into ```<Project Directory>/asnide/workspace/asnide/asn1-pusc-lib/service-01/ErrorCodes.asn1``` .